### PR TITLE
Adds default of multiplicity to workaround parsing issues

### DIFF
--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -190,7 +190,12 @@ class gen_qrc:
         data = parser.parse()
 
         #try:
-        nat, charge, mult, atomnos = data.natom, data.charge, data.mult, data.atomnos
+        nat, charge, atomnos = data.natom, data.charge, data.atomnos
+        try:
+            mult = data.mult 
+        except:
+            AttributeError 
+            mult = 1    # surface level workaround to set default value of multiplicity to 1 if not parsed properly by cclib
         elements = [periodictable[z] for z in atomnos]
         cartesians = data.atomcoords[-1]
         freq, disps = data.vibfreqs, data.vibdisps

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -195,7 +195,8 @@ class gen_qrc:
             mult = data.mult 
         except:
             AttributeError 
-            mult = 1    # surface level workaround to set default value of multiplicity to 1 if not parsed properly by cclib
+            mult = '1'    # surface level workaround to set default value of multiplicity to 1 if not parsed properly by cclib
+            print('Warning - multiplicity not parsed from input: defaulted to 1 in input files')
         elements = [periodictable[z] for z in atomnos]
         cartesians = data.atomcoords[-1]
         freq, disps = data.vibfreqs, data.vibdisps


### PR DESCRIPTION
CCLIB parse of multiplicity can fail (eg. xtb through ORCA) and terminates script
Surface level try/except workaround with a default multiplicity set to 1
Also prints a warning so that this behaviour is known to the user
- Doesn't offer the user an ability to choose their default