### PR TITLE
Milestones 0 & 1: packaging fix, loud CLI failures, --freq tolerance (v2.2.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@5
-
 jobs:
   test:
     parameters:
@@ -20,8 +17,11 @@ jobs:
       - run:
           name: Run tests with coverage
           command: pytest --cov=pyqrc --cov-report=xml -v
-      - codecov/upload:
-          files: coverage.xml
+      - run:
+          name: Upload coverage to Codecov (non-blocking)
+          command: |
+            pip install codecov-cli
+            codecovcli upload-process --file coverage.xml || echo "Codecov upload failed; not failing the build"
 
   package:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,31 @@ jobs:
       - codecov/upload:
           files: coverage.xml
 
+  package:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: Build wheel
+          command: |
+            pip install --upgrade pip build
+            python -m build --wheel --outdir dist/
+      - run:
+          name: Verify wheel contents
+          command: |
+            unzip -l dist/*.whl
+            unzip -l dist/*.whl | grep "pyqrc/run_g16.sh"
+      - run:
+          name: Install wheel in clean venv and smoke-test CLI
+          command: |
+            python -m venv /tmp/venv
+            /tmp/venv/bin/pip install dist/*.whl
+            mkdir /tmp/smoke && cd /tmp/smoke
+            cp ~/project/examples/g16/acetaldehyde.log .
+            /tmp/venv/bin/pyqrc acetaldehyde.log
+            test -f acetaldehyde_QRC.com
+
 workflows:
   test:
     jobs:
@@ -30,3 +55,4 @@ workflows:
           matrix:
             parameters:
               python-version: ["3.9", "3.10", "3.11", "3.12"]
+      - package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*
+      - name: Verify wheel contents
+        run: unzip -l dist/*.whl | grep "pyqrc/run_g16.sh"
+      - name: Verify release tag matches package version
+        run: |
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Release tag v$TAG_VERSION does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyqrc
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,11 @@ ENV/
 env.bak/
 venv.bak/
 
-# IDE
+# IDE / AI assistant
 .idea/
 .vscode/
 .claude/
+CLAUDE.md
 *.swp
 *.swo
 *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
 include LICENSE
-recursive-include pyqrc/examples *
+include pyqrc/run_g16.sh

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ python -m pyqrc [options] <output_file(s)>
 | `--name SUFFIX` | String appended to the filename for new input file(s). | `QRC` |
 | `-q, --quiet` | Suppress verbose output (skips the `.qrc` summary file). | Verbose by default |
 | `--auto` | Only process files with imaginary frequencies, skip others. | Disabled |
-| `-f, --freq VALUE` | Displace along a specific frequency (in cm⁻¹). | All imaginary |
-| `--freqnum N` | Displace along frequency number N (from lowest). | All imaginary |
+| `-f, --freq VALUE` | Displace along the normal mode nearest this frequency (cm⁻¹); errors if no mode is within 1 cm⁻¹. | All imaginary |
+| `--freqnum N` | Displace along frequency number N (from lowest); errors if N exceeds the number of modes. | All imaginary |
 | `--qcoord` | Automatic single point calculations along normal modes. | Disabled |
 | `--nummodes N` | Number of modes for `--qcoord` calculations. | `all` |
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ pixi add --pypi pyqrc
 **From source:**
 Clone the repository https://github.com/patonlab/pyQRC.git and add to your PYTHONPATH variable.
 
+### ORCA 6 compatibility
+
+Parsing ORCA 6 output files requires a newer cclib than the current PyPI release (1.8.1), which fails on ORCA 6's SCF block. Until cclib ships a release with the fix, install cclib from GitHub master alongside pyQRC:
+
+```bash
+pip install pyqrc
+pip install --upgrade 'git+https://github.com/cclib/cclib.git'
+```
+
+Note: cclib master currently has a regression affecting some Q-Chem outputs. If you primarily use Q-Chem, stay on cclib 1.8.1.
+
 Then run the script as a Python module with your computational chemistry output files (the program expects `.log` or `.out` extensions) and can accept wildcard arguments.
 
 ## Usage
@@ -66,7 +77,7 @@ python -m pyqrc [options] <output_file(s)>
 | `--mem NGB` | Memory requested in the new input file. Format: `XGB` or `X000MB`. | `4GB` |
 | `--route 'THEORY/BASIS'` | Route line for the new calculation. | Same as original |
 | `--name SUFFIX` | String appended to the filename for new input file(s). | `QRC` |
-| `-v` | Verbose output. | Enabled |
+| `-q, --quiet` | Suppress verbose output (skips the `.qrc` summary file). | Verbose by default |
 | `--auto` | Only process files with imaginary frequencies, skip others. | Disabled |
 | `-f, --freq VALUE` | Displace along a specific frequency (in cm⁻¹). | All imaginary |
 | `--freqnum N` | Displace along frequency number N (from lowest). | All imaginary |
@@ -133,6 +144,18 @@ To benchmark QRC against intrinsic reaction coordinate (IRC) calculations, 544 t
 | 0.5       | 0.58                   | 3.44                      | 98.7%          | 98.2%         |
 
 An amplitude of **0.3** gives the best overall performance, with the highest SMILES match rates for both reactants and products (98.9%) and low MAE for barriers (0.65 kcal/mol) and reaction energies (1.39 kcal/mol). While an amplitude of 0.5 gives a marginally lower barrier MAE (0.58 kcal/mol), it produces larger errors in reaction energies and lower product match rates. An amplitude of 0.1 gives insufficient displacement, leading to higher energy errors and more mismatched products. Full details and data are available in the [irc_comparison](irc_comparison/analysis/) directory.
+
+## Development
+
+```bash
+git clone https://github.com/patonlab/pyQRC.git
+cd pyQRC
+pip install -e ".[dev]"
+pytest            # run the test suite
+pylint pyqrc      # lint (CI requires a score >= 9.0)
+```
+
+Planned work is tracked in [ROADMAP.md](ROADMAP.md).
 
 ## Citation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,71 @@
+# pyQRC Roadmap
+
+Derived from a full repository audit (June 2026). Tasks are ordered by
+milestone; within a milestone they can proceed in parallel unless a dependency
+is listed. Sizes: **S** < 2 h, **M** ≈ half a day, **L** = 1–2 days.
+
+**Definition of done for this roadmap:**
+- CI builds the wheel, installs it in a clean venv, and smoke-tests `pyqrc` (and the wheel contains `run_g16.sh`).
+- `pyqrc missing.log` exits non-zero with a message.
+- `--freq` / `--freqnum` with no matching mode exits non-zero and writes **no** input file.
+- `cclib` has version bounds in `pyproject.toml`.
+- `pytest` reports zero skips when run in the repo.
+- README options table matches `pyqrc --help` exactly.
+
+---
+
+## Decisions
+
+Proposed answers to the audit's open questions. Treat as accepted defaults
+unless overridden; tasks below assume them.
+
+| # | Question | Decision (proposed) | Rationale |
+|---|----------|---------------------|-----------|
+| D1 | Keep or deprecate `--qcoord`? | **Keep, fix packaging (1.1), defer robustness work (3.1)** until there is evidence of use. | Shipping `run_g16.sh` is a one-line fix; the absence of bug reports for a long-broken mode suggests low usage, so don't invest beyond that yet. |
+| D2 | Ship `examples/` in the wheel? | **No — repo-only.** Remove the dead `package-data`/`MANIFEST.in` references; optionally include examples in the sdist only. | They are test fixtures/docs (~MBs of QM output); installed users don't need them, and conftest already resolves repo-relative paths. |
+| D3 | cclib pinning policy | **Bound now: `cclib>=1.8.1,<2`; raise the floor to the first release containing the ORCA 6 fix when it ships**, then make the ORCA 6 example a tested fixture. | Matches the compatibility matrix the README already documents; an upper bound protects against the known master-branch Q-Chem regression pattern. |
+| D4 | `--freq` matching semantics | **Nearest mode within ±1 cm⁻¹ (configurable), print the matched mode; no match → error, no file, exit 1.** Release as **v2.2.0** with a release note. | Frequencies are reported to ~0.1 cm⁻¹; exact float equality can never be the intended UX. Previously "successful" no-op runs becoming errors is the point of the fix. |
+| D5 | Python 3.13 support | **Yes — add 3.13 to both CI matrices and the classifiers.** | Pure-Python package; local development already happens on 3.13; risk is in cclib, which CI will reveal. |
+
+---
+
+## Milestone 0 — Safety Net
+
+| # | Task | Files | Acceptance criteria | Size | Risk | Deps |
+|---|------|-------|---------------------|------|------|------|
+| 0.1 | Commit pending working-tree changes (README ORCA-6 section, test except-clauses; track `examples/orca6/full_alkyne_TS.out`) | `README.md`, `tests/test_pyqrc.py`, `examples/orca6/` | `git status` clean; CI green | S | None | — |
+| 0.2 | Add wheel-build + clean-venv install + smoke test to CircleCI: build wheel, assert it contains `pyqrc/run_g16.sh`, `pip install` it in a fresh venv, run `pyqrc` on `examples/g16/acetaldehyde.log` in a tmpdir, assert `acetaldehyde_QRC.com` is created | `.circleci/config.yml` | Job exists and **fails on current master** (proving it catches the packaging bug) | S | None | — |
+| 0.3 | Characterization tests for desired CLI failure modes, marked `xfail(strict=True)`: missing file → exit 1 + message; unmatched `--freq` → exit 1, no file written; out-of-range `--freqnum` → exit 1, no file written | `tests/test_pyqrc.py` | Tests xfail today; flip to pass with 1.2/1.3 | S | None | — |
+
+## Milestone 1 — Critical Fixes
+
+| # | Task | Files | Acceptance criteria | Size | Risk | Deps |
+|---|------|-------|---------------------|------|------|------|
+| 1.1 | **Fix packaging** per D1/D2: add `pyqrc = ["run_g16.sh"]` to `[tool.setuptools.package-data]`; delete the dead `recursive-include pyqrc/examples *` from `MANIFEST.in` (add root `examples/` to the sdist only if desired) | `pyproject.toml`, `MANIFEST.in` | 0.2's CI job passes; `unzip -l` of the wheel shows `pyqrc/run_g16.sh` | S | Low | 0.2 |
+| 1.2 | **Fix `--freq`/`--freqnum` matching** per D4: nearest-match within tolerance computed once before the shift loop; if the user requested a specific mode and nothing matched, raise (new `QRCModeError` or `QRCParseError` subclass) **before any file is written**; move `main()`'s "processing" message after successful generation. Bump version to 2.2.0 | `pyqrc/pyQRC.py` (`_calculate_shifts`, `QRCGenerator.__init__`, `main`), `tests/test_pyqrc.py` | 0.3 xfails flip to pass; `--freq -500` vs actual −500.123 displaces along that mode and says so; `--freqnum 99` errors with no file. Update the two tests that assert the old no-op behavior (`-f -500` cases) | M | **Medium — behavior change; needs release note** | 0.3 |
+| 1.3 | **Collect files from `args.files`**, not a `sys.argv` re-scan: glob each entry (literal existing paths glob to themselves); no match → `x   <entry>: no such file`, exit code 1; warn-and-skip unexpected extensions; remove the dead `except IndexError` | `pyqrc/pyQRC.py` (`main`) | `pyqrc typo.log` exits 1 with a message; `--name backup.log` no longer captures the option value as an input | S | Low | 0.3 |
+
+## Milestone 2 — High-Leverage Improvements
+
+| # | Task | Files | Acceptance criteria | Size | Risk | Deps |
+|---|------|-------|---------------------|------|------|------|
+| 2.1 | Dependency bounds per D3: `cclib>=1.8.1,<2`, `numpy>=1.22`; README support-matrix note | `pyproject.toml`, `README.md` | Fresh install resolves to a combination the suite passes on | S | Low | — |
+| 2.2 | Refactor `QRCGenerator.__init__` into `_parse()` → `compute_displacement()` (pure: copies coords, never mutates cclib data) → `write_files()`; `__init__` calls all three (backwards-compatible); use `with Logger(...)` at all call sites so handles can't leak on exceptions | `pyqrc/pyQRC.py` | All existing tests pass unmodified; new unit test obtains displaced coordinates with zero files written | M | Medium | 0.3 |
+| 2.3 | De-skip the suite: remove existence-checks/skips for fixtures that live in the repo; cclib parse failures on repo examples become failures or strict xfails with a tracked reason | `tests/test_pyqrc.py`, `tests/conftest.py` | `pytest` reports 0 skips in-repo | M | Low | 2.1 |
+| 2.4 | Single-source the version (keep one literal; others read it, e.g. `importlib.metadata`) | `pyproject.toml`, `pyqrc/__init__.py`, `pyqrc/pyQRC.py` | Version string appears in exactly one file | S | Low | — |
+
+## Milestone 3 — Quality & Polish
+
+| # | Task | Files | Acceptance criteria | Size | Risk | Deps |
+|---|------|-------|---------------------|------|------|------|
+| 3.1 | `--qcoord` robustness (only if D1 usage evidence appears): open the RUNIRC log once per run (not per file, which truncates it); try/except around per-file work; hoist `OutputData` out of the amplitude loop | `pyqrc/pyQRC.py` | Multi-file `--qcoord` keeps one complete log; one bad file doesn't abort the batch | M | Medium | 2.2 |
+| 3.2 | Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`; error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; delete the unused `TERMINATION` attribute or use it to warn on abnormal termination | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
+| 3.3 | CI/lint tidy-up: pylint workflow on `[push, pull_request]`; add ruff to dev deps + CI **or** delete the orphan `[tool.ruff.lint]` config; add Python 3.13 to both CI matrices and classifiers (D5) | `.github/workflows/pylint.yml`, `pyproject.toml`, `.circleci/config.yml` | PRs from forks get linted; no orphan tool config; 3.13 green | S | Low | — |
+| 3.4 | Audit the README options table against `pyqrc --help` (the `-v` → `-q` fix is already done) | `README.md` | Table matches `--help` verbatim | S | None | 1.2 |
+
+## Quick wins (all S, can be done immediately)
+
+1. ~~Fix the phantom `-v` row in the README options table~~ ✅ done June 2026
+2. Commit pending working-tree changes (0.1)
+3. Wheel-content CI check (0.2)
+4. Pylint on `pull_request` (part of 3.3)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,3 +73,13 @@ unless overridden; tasks below assume them.
 **Milestones 0 and 1 are complete** (June 2026): packaging fixed and CI-guarded,
 missing files and unmatched `--freq`/`--freqnum` now fail loudly, version bumped
 to 2.2.0 (needs a PyPI release). Next up: Milestone 2.
+
+## Releasing
+
+Publishing is automated via PyPI Trusted Publishing
+(`.github/workflows/publish.yml`): create a GitHub Release with tag
+`v<version>` (matching `pyproject.toml`) and the workflow builds, verifies
+wheel contents and the tag/version match, and uploads to PyPI.
+One-time setup required on pypi.org → project `pyqrc` → Publishing →
+add trusted publisher (owner `patonlab`, repo `pyQRC`, workflow
+`publish.yml`, environment `pypi`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,8 @@ unless overridden; tasks below assume them.
 | D4 | `--freq` matching semantics | **Nearest mode within ±1 cm⁻¹ (configurable), print the matched mode; no match → error, no file, exit 1.** Release as **v2.2.0** with a release note. | Frequencies are reported to ~0.1 cm⁻¹; exact float equality can never be the intended UX. Previously "successful" no-op runs becoming errors is the point of the fix. |
 | D5 | Python 3.13 support | **Yes — add 3.13 to both CI matrices and the classifiers.** | Pure-Python package; local development already happens on 3.13; risk is in cclib, which CI will reveal. |
 
+Note (D3): per the README "ORCA 6 compatibility" section, cclib 1.8.1 is incompatible with ORCA 6 parsing, so ORCA 6 support is excluded until a fixed cclib release is published.
+
 ---
 
 ## Milestone 0 — Safety Net
@@ -59,7 +61,7 @@ unless overridden; tasks below assume them.
 | # | Task | Files | Acceptance criteria | Size | Risk | Deps |
 |---|------|-------|---------------------|------|------|------|
 | 3.1 | `--qcoord` robustness (only if D1 usage evidence appears): open the RUNIRC log once per run (not per file, which truncates it); try/except around per-file work; hoist `OutputData` out of the amplitude loop | `pyqrc/pyQRC.py` | Multi-file `--qcoord` keeps one complete log; one bad file doesn't abort the batch | M | Medium | 2.2 |
-| 3.2 | Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`; error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; delete the unused `TERMINATION` attribute or use it to warn on abnormal termination | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
+| 3.2 | ~~Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`~~ (✅ done June 2026); error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; delete the unused `TERMINATION` attribute or use it to warn on abnormal termination | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
 | 3.3 | CI/lint tidy-up: pylint workflow on `[push, pull_request]`; add ruff to dev deps + CI **or** delete the orphan `[tool.ruff.lint]` config; add Python 3.13 to both CI matrices and classifiers (D5) | `.github/workflows/pylint.yml`, `pyproject.toml`, `.circleci/config.yml` | PRs from forks get linted; no orphan tool config; 3.13 green | S | Low | — |
 | 3.4 | Audit the README options table against `pyqrc --help` (the `-v` → `-q` fix is already done) | `README.md` | Table matches `--help` verbatim | S | None | 1.2 |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,17 +33,17 @@ unless overridden; tasks below assume them.
 
 | # | Task | Files | Acceptance criteria | Size | Risk | Deps |
 |---|------|-------|---------------------|------|------|------|
-| 0.1 | Commit pending working-tree changes (README ORCA-6 section, test except-clauses; track `examples/orca6/full_alkyne_TS.out`) | `README.md`, `tests/test_pyqrc.py`, `examples/orca6/` | `git status` clean; CI green | S | None | — |
-| 0.2 | Add wheel-build + clean-venv install + smoke test to CircleCI: build wheel, assert it contains `pyqrc/run_g16.sh`, `pip install` it in a fresh venv, run `pyqrc` on `examples/g16/acetaldehyde.log` in a tmpdir, assert `acetaldehyde_QRC.com` is created | `.circleci/config.yml` | Job exists and **fails on current master** (proving it catches the packaging bug) | S | None | — |
-| 0.3 | Characterization tests for desired CLI failure modes, marked `xfail(strict=True)`: missing file → exit 1 + message; unmatched `--freq` → exit 1, no file written; out-of-range `--freqnum` → exit 1, no file written | `tests/test_pyqrc.py` | Tests xfail today; flip to pass with 1.2/1.3 | S | None | — |
+| 0.1 ✅ | Commit pending working-tree changes (README ORCA-6 section, test except-clauses; track `examples/orca6/full_alkyne_TS.out`) | `README.md`, `tests/test_pyqrc.py`, `examples/orca6/` | `git status` clean; CI green | S | None | — |
+| 0.2 ✅ | Add wheel-build + clean-venv install + smoke test to CircleCI: build wheel, assert it contains `pyqrc/run_g16.sh`, `pip install` it in a fresh venv, run `pyqrc` on `examples/g16/acetaldehyde.log` in a tmpdir, assert `acetaldehyde_QRC.com` is created | `.circleci/config.yml` | Job exists and **fails on current master** (proving it catches the packaging bug) | S | None | — |
+| 0.3 ✅ | Characterization tests for desired CLI failure modes, marked `xfail(strict=True)`: missing file → exit 1 + message; unmatched `--freq` → exit 1, no file written; out-of-range `--freqnum` → exit 1, no file written | `tests/test_pyqrc.py` | Tests xfail today; flip to pass with 1.2/1.3 | S | None | — |
 
 ## Milestone 1 — Critical Fixes
 
 | # | Task | Files | Acceptance criteria | Size | Risk | Deps |
 |---|------|-------|---------------------|------|------|------|
-| 1.1 | **Fix packaging** per D1/D2: add `pyqrc = ["run_g16.sh"]` to `[tool.setuptools.package-data]`; delete the dead `recursive-include pyqrc/examples *` from `MANIFEST.in` (add root `examples/` to the sdist only if desired) | `pyproject.toml`, `MANIFEST.in` | 0.2's CI job passes; `unzip -l` of the wheel shows `pyqrc/run_g16.sh` | S | Low | 0.2 |
-| 1.2 | **Fix `--freq`/`--freqnum` matching** per D4: nearest-match within tolerance computed once before the shift loop; if the user requested a specific mode and nothing matched, raise (new `QRCModeError` or `QRCParseError` subclass) **before any file is written**; move `main()`'s "processing" message after successful generation. Bump version to 2.2.0 | `pyqrc/pyQRC.py` (`_calculate_shifts`, `QRCGenerator.__init__`, `main`), `tests/test_pyqrc.py` | 0.3 xfails flip to pass; `--freq -500` vs actual −500.123 displaces along that mode and says so; `--freqnum 99` errors with no file. Update the two tests that assert the old no-op behavior (`-f -500` cases) | M | **Medium — behavior change; needs release note** | 0.3 |
-| 1.3 | **Collect files from `args.files`**, not a `sys.argv` re-scan: glob each entry (literal existing paths glob to themselves); no match → `x   <entry>: no such file`, exit code 1; warn-and-skip unexpected extensions; remove the dead `except IndexError` | `pyqrc/pyQRC.py` (`main`) | `pyqrc typo.log` exits 1 with a message; `--name backup.log` no longer captures the option value as an input | S | Low | 0.3 |
+| 1.1 ✅ | **Fix packaging** per D1/D2: add `pyqrc = ["run_g16.sh"]` to `[tool.setuptools.package-data]`; delete the dead `recursive-include pyqrc/examples *` from `MANIFEST.in` (add root `examples/` to the sdist only if desired) | `pyproject.toml`, `MANIFEST.in` | 0.2's CI job passes; `unzip -l` of the wheel shows `pyqrc/run_g16.sh` | S | Low | 0.2 |
+| 1.2 ✅ | **Fix `--freq`/`--freqnum` matching** per D4: nearest-match within tolerance computed once before the shift loop; if the user requested a specific mode and nothing matched, raise (new `QRCModeError` or `QRCParseError` subclass) **before any file is written**; move `main()`'s "processing" message after successful generation. Bump version to 2.2.0 | `pyqrc/pyQRC.py` (`_calculate_shifts`, `QRCGenerator.__init__`, `main`), `tests/test_pyqrc.py` | 0.3 xfails flip to pass; `--freq -500` vs actual −500.123 displaces along that mode and says so; `--freqnum 99` errors with no file. Update the two tests that assert the old no-op behavior (`-f -500` cases) | M | **Medium — behavior change; needs release note** | 0.3 |
+| 1.3 ✅ | **Collect files from `args.files`**, not a `sys.argv` re-scan: glob each entry (literal existing paths glob to themselves); no match → `x   <entry>: no such file`, exit code 1; warn-and-skip unexpected extensions; remove the dead `except IndexError` | `pyqrc/pyQRC.py` (`main`) | `pyqrc typo.log` exits 1 with a message; `--name backup.log` no longer captures the option value as an input | S | Low | 0.3 |
 
 ## Milestone 2 — High-Leverage Improvements
 
@@ -66,6 +66,10 @@ unless overridden; tasks below assume them.
 ## Quick wins (all S, can be done immediately)
 
 1. ~~Fix the phantom `-v` row in the README options table~~ ✅ done June 2026
-2. Commit pending working-tree changes (0.1)
-3. Wheel-content CI check (0.2)
-4. Pylint on `pull_request` (part of 3.3)
+2. ~~Commit pending working-tree changes (0.1)~~ ✅ done June 2026
+3. ~~Wheel-content CI check (0.2)~~ ✅ done June 2026
+4. ~~Pylint on `pull_request` (part of 3.3)~~ ✅ done June 2026
+
+**Milestones 0 and 1 are complete** (June 2026): packaging fixed and CI-guarded,
+missing files and unmatched `--freq`/`--freqnum` now fail loudly, version bumped
+to 2.2.0 (needs a PyPI release). Next up: Milestone 2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ packages = ["pyqrc"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-pyqrc = ["examples/*"]
+pyqrc = ["run_g16.sh"]
 
 [tool.pylint.main]
 py-version = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyqrc"
-version = "2.1.0"
+version = "2.2.0"
 description = "A Python program to project computed structures along normal modes for Quick Reaction Coordinate calculations"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyqrc/__init__.py
+++ b/pyqrc/__init__.py
@@ -8,6 +8,7 @@ displacing molecular structures along normal modes.
 from pyqrc.pyQRC import (
     QRCGenerator,
     QRCParseError,
+    QRCModeError,
     OutputData,
     Logger,
     mwdist,
@@ -18,13 +19,14 @@ from pyqrc.pyQRC import (
     COVALENT_RADII,
 )
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __author__ = "Robert Paton"
 __email__ = "robert.paton@colostate.edu"
 
 __all__ = [
     "QRCGenerator",
     "QRCParseError",
+    "QRCModeError",
     "OutputData",
     "Logger",
     "mwdist",

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -727,17 +727,21 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Collect input files
+    # Collect input files, expanding any glob patterns the shell left unexpanded
     files = []
-    for elem in sys.argv[1:]:
-        try:
-            if os.path.splitext(elem)[1] in [".out", ".log"]:
-                for file in glob(elem):
-                    files.append(file)
-        except IndexError:
-            pass
-
     exit_code = 0
+    for pattern in args.files:
+        matches = sorted(glob(pattern))
+        if not matches:
+            print(f'x   {pattern}: no such file')
+            exit_code = 1
+            continue
+        for file in matches:
+            if os.path.splitext(file)[1] not in ('.out', '.log'):
+                print(f'x   {file} skipped: expected a .log or .out file')
+                exit_code = 1
+                continue
+            files.append(file)
     for file in files:
         # Parse output with cclib and count imaginary frequencies
         try:

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -55,7 +55,7 @@ def working_directory(path: Path) -> Generator[None, None, None]:
         os.chdir(original_dir)
 
 # Constants
-BOHR_TO_ANGSTROM = 1.88972612456506
+ANGSTROM_TO_BOHR = 1.88972612456506
 DEFAULT_AMPLITUDE = 0.2
 FREQ_MATCH_TOLERANCE = 1.0  # cm-1, for matching a user-requested --freq value
 DEFAULT_NPROC = 1
@@ -315,7 +315,7 @@ def mwdist(coords1: np.ndarray, coords2: np.ndarray, elements: list[int]) -> flo
     for n, atom in enumerate(elements):
         dist += ATOMIC_MASSES[atom] * (np.linalg.norm(coords1[n] - coords2[n])) ** 2
 
-    return BOHR_TO_ANGSTROM * dist ** 0.5
+    return ANGSTROM_TO_BOHR * dist ** 0.5
 
 
 def gen_overlap(mol_atoms: list[str], coords: np.ndarray, covfrac: float) -> np.ndarray:
@@ -547,6 +547,10 @@ class QRCGenerator:
             return {num - 1}
 
         if val is not None:
+            if nmodes == 0:
+                raise QRCModeError(
+                    f"requested frequency {val} cm-1 cannot be matched: no vibrational modes are available"
+                )
             nearest = min(range(nmodes), key=lambda mode: abs(freq[mode] - val))
             if abs(freq[nearest] - val) > FREQ_MATCH_TOLERANCE:
                 raise QRCModeError(
@@ -816,11 +820,11 @@ def main() -> int:
                     continue
 
                 if args.freq is not None:
-                    print(f'o   {file} will be distorted along {args.freq} cm-1: processing')
+                    print(f'o   {file} was distorted along {args.freq} cm-1')
                 elif args.freqnum is not None:
-                    print(f'o   {file} will be distorted along freq #{args.freqnum}: processing')
+                    print(f'o   {file} was distorted along freq #{args.freqnum}')
                 else:
-                    print(f'o   {file} has {im_freq} imaginary frequencies: processing')
+                    print(f'o   {file} had {im_freq} imaginary frequencies: processed')
 
         else:
             # Automatic calculations (single points for stability check)

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -10,7 +10,7 @@ Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;
           Tet. Lett. 2005, 46, 2067-2069.
 """
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 __author__ = 'Robert Paton'
 __email__ = 'robert.paton@colostate.edu'
 
@@ -33,6 +33,10 @@ class QRCParseError(Exception):
     """Raised when parsing a computational chemistry output file fails."""
 
 
+class QRCModeError(Exception):
+    """Raised when a requested normal mode or frequency cannot be matched."""
+
+
 @contextmanager
 def working_directory(path: Path) -> Generator[None, None, None]:
     """Context manager for changing working directory with automatic restoration.
@@ -53,6 +57,7 @@ def working_directory(path: Path) -> Generator[None, None, None]:
 # Constants
 BOHR_TO_ANGSTROM = 1.88972612456506
 DEFAULT_AMPLITUDE = 0.2
+FREQ_MATCH_TOLERANCE = 1.0  # cm-1, for matching a user-requested --freq value
 DEFAULT_NPROC = 1
 DEFAULT_MEMORY = "4GB"
 DEFAULT_SUFFIX = "QRC"
@@ -426,17 +431,19 @@ class QRCGenerator:
         self.CARTESIAN = cartesians.copy()
         self.ATOMTYPES = elements
 
+        # Resolve which modes to displace along before any output is written,
+        # so an unmatched request leaves no files behind
+        target_modes = self._resolve_target_modes(freq, val, num)
+
         # Write verbose output file
         log = None
         if verbose:
             log = Logger(file_path.stem, "qrc", suffix)
             self._write_header(log, elements, cartesians, nat, freq, rmass, fconst, nmodes)
 
-        # Note: Original coordinates are stored in self.CARTESIAN
-
         # Calculate shifts based on user input
         shift = self._calculate_shifts(
-            freq, amplitude, val, num, verbose, log, elements, disps, nat
+            freq, amplitude, target_modes, verbose, log, elements, disps, nat
         )
 
         # Apply displacements to generate perturbed structure
@@ -510,12 +517,51 @@ class QRCGenerator:
         for mode in range(nmodes):
             log.write(f'{freq[mode]:24.4f} {rmass[mode]:9.4f} {fconst[mode]:9.4f}')
 
+    @staticmethod
+    def _resolve_target_modes(
+        freq: np.ndarray,
+        val: Optional[float],
+        num: Optional[int]
+    ) -> set:
+        """Resolve which normal modes to displace along.
+
+        Args:
+            freq: Vibrational frequencies (cm^-1).
+            val: Specific frequency value (cm^-1) requested by the user, if any.
+            num: Specific mode number (1-indexed) requested by the user, if any.
+
+        Returns:
+            Set of 0-indexed mode numbers to shift. Defaults to all
+            imaginary modes when no specific mode was requested.
+
+        Raises:
+            QRCModeError: If a specifically requested mode cannot be matched.
+        """
+        nmodes = len(freq)
+
+        if num is not None:
+            if not 1 <= num <= nmodes:
+                raise QRCModeError(
+                    f"requested mode {num} is out of range: file has {nmodes} normal modes"
+                )
+            return {num - 1}
+
+        if val is not None:
+            nearest = min(range(nmodes), key=lambda mode: abs(freq[mode] - val))
+            if abs(freq[nearest] - val) > FREQ_MATCH_TOLERANCE:
+                raise QRCModeError(
+                    f"no normal mode within {FREQ_MATCH_TOLERANCE} cm-1 of {val} cm-1 "
+                    f"(nearest: {freq[nearest]:.4f} cm-1)"
+                )
+            return {nearest}
+
+        return {mode for mode, wn in enumerate(freq) if wn < 0.0}
+
     def _calculate_shifts(
         self,
         freq: np.ndarray,
         amplitude: float,
-        val: Optional[float],
-        num: Optional[int],
+        target_modes: set,
         verbose: bool,
         log: Optional[Logger],
         elements: list[str],
@@ -526,14 +572,7 @@ class QRCGenerator:
         shift = []
 
         for mode, wn in enumerate(freq):
-            # Move along imaginary freqs, or a specific mode requested by user
-            should_shift = (
-                (wn < 0.0 and val is None and num is None) or
-                (wn == val) or
-                (mode + 1 == num)
-            )
-
-            if should_shift:
+            if mode in target_modes:
                 shift.append(amplitude)
                 if verbose and log:
                     log.write('\n                -SHIFTING ALONG NORMAL MODE-')
@@ -766,21 +805,22 @@ def main() -> int:
             if im_freq == 0 and args.auto:
                 print(f'x   {file} has no imaginary frequencies: skipping')
             else:
-                if args.freq is None and args.freqnum is None:
-                    print(f'o   {file} has {im_freq} imaginary frequencies: processing')
-                elif args.freq is not None:
-                    print(f'o   {file} will be distorted along {args.freq} cm-1: processing')
-                elif args.freqnum is not None:
-                    print(f'o   {file} will be distorted along freq #{args.freqnum}: processing')
-
                 try:
                     QRCGenerator(
                         file, args.amplitude, args.nproc, args.mem, args.route,
                         args.verbose, args.suffix, args.freq, args.freqnum
                     )
-                except QRCParseError as exc:
+                except (QRCParseError, QRCModeError) as exc:
                     print(f'x   {file} failed: {exc}')
                     exit_code = 1
+                    continue
+
+                if args.freq is not None:
+                    print(f'o   {file} will be distorted along {args.freq} cm-1: processing')
+                elif args.freqnum is not None:
+                    print(f'o   {file} will be distorted along freq #{args.freqnum}: processing')
+                else:
+                    print(f'o   {file} has {im_freq} imaginary frequencies: processing')
 
         else:
             # Automatic calculations (single points for stability check)

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -607,7 +607,7 @@ class TestMain:
         main()
 
         captured = capsys.readouterr()
-        assert 'imaginary frequencies: processing' in captured.out
+        assert 'imaginary frequencies: processed' in captured.out
 
 
 class TestOutputDataExtended:
@@ -1815,6 +1815,10 @@ class TestResolveTargetModes:
     def test_freqnum_zero_raises(self):
         with pytest.raises(QRCModeError, match="out of range"):
             QRCGenerator._resolve_target_modes(self.FREQS, None, 0)
+
+    def test_empty_freq_with_val_raises(self):
+        with pytest.raises(QRCModeError, match="no vibrational modes are available"):
+            QRCGenerator._resolve_target_modes(np.array([]), -500.0, None)
 
 
 class TestMainModule:

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -16,6 +16,7 @@ from pyqrc.pyQRC import (
     Logger,
     OutputData,
     QRCGenerator,
+    QRCModeError,
     QRCParseError,
     check_overlap,
     element_id,
@@ -548,14 +549,19 @@ class TestMain:
         if not g16_claisen_ts.exists():
             pytest.skip("Gaussian TS test file not found")
 
+        import cclib
+
         shutil.copy(g16_claisen_ts, temp_workdir)
         local_file = temp_workdir / g16_claisen_ts.name
 
-        # Use a frequency value that exists in the file
-        monkeypatch.setattr('sys.argv', ['pyqrc', '-f', '-500', str(local_file)])
-        main()
+        # A value within the matching tolerance of the imaginary frequency
+        data = cclib.io.ccopen(str(local_file)).parse()
+        target = round(float(data.vibfreqs[0]), 1)
 
-        # Should still create output even if freq doesn't exactly match
+        monkeypatch.setattr('sys.argv', ['pyqrc', '-f', str(target), str(local_file)])
+        exit_code = main()
+
+        assert exit_code == 0
         assert (temp_workdir / f"{local_file.stem}_QRC.com").exists()
 
     def test_main_with_freqnum_option(self, g16_claisen_ts, temp_workdir, monkeypatch):
@@ -1067,10 +1073,15 @@ class TestPrintOutput:
         if not g16_claisen_ts.exists():
             pytest.skip("Gaussian TS test file not found")
 
+        import cclib
+
         shutil.copy(g16_claisen_ts, temp_workdir)
         local_file = temp_workdir / g16_claisen_ts.name
 
-        monkeypatch.setattr('sys.argv', ['pyqrc', '-f', '-500.0', str(local_file)])
+        data = cclib.io.ccopen(str(local_file)).parse()
+        target = round(float(data.vibfreqs[0]), 1)
+
+        monkeypatch.setattr('sys.argv', ['pyqrc', '-f', str(target), str(local_file)])
         main()
 
         captured = capsys.readouterr()
@@ -1735,11 +1746,7 @@ class TestQcoordMode:
 
 
 class TestCLIFailureModes:
-    """Characterization tests for desired CLI failure behavior (ROADMAP 0.3).
-
-    Marked strict-xfail until the corresponding fixes land:
-    missing files (1.3), unmatched --freq / out-of-range --freqnum (1.2).
-    """
+    """CLI failure behavior: bad inputs must fail loudly (ROADMAP 0.3/1.2/1.3)."""
 
     def test_missing_file_exits_nonzero(self, tmp_path, monkeypatch, capsys):
         """A nonexistent input file should produce an error message and exit 1."""
@@ -1751,7 +1758,6 @@ class TestCLIFailureModes:
         assert exit_code == 1
         assert 'no such file' in captured.out
 
-    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.2: unmatched --freq currently writes an undisplaced input")
     def test_unmatched_freq_errors_and_writes_nothing(self, g16_claisen_ts, temp_workdir, monkeypatch, capsys):
         """--freq matching no normal mode should exit 1 and write no input file."""
         shutil.copy(g16_claisen_ts, temp_workdir)
@@ -1766,7 +1772,6 @@ class TestCLIFailureModes:
         assert 'failed' in captured.out
         assert not (temp_workdir / f"{local_file.stem}_QRC.com").exists()
 
-    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.2: out-of-range --freqnum currently writes an undisplaced input")
     def test_out_of_range_freqnum_errors_and_writes_nothing(self, g16_claisen_ts, temp_workdir, monkeypatch, capsys):
         """--freqnum beyond the number of modes should exit 1 and write no input file."""
         shutil.copy(g16_claisen_ts, temp_workdir)
@@ -1779,6 +1784,37 @@ class TestCLIFailureModes:
         assert exit_code == 1
         assert 'failed' in captured.out
         assert not (temp_workdir / f"{local_file.stem}_QRC.com").exists()
+
+
+class TestResolveTargetModes:
+    """Unit tests for QRCGenerator._resolve_target_modes."""
+
+    FREQS = np.array([-536.5, 102.3, 250.0, 1700.8])
+
+    def test_default_selects_imaginary_modes(self):
+        modes = QRCGenerator._resolve_target_modes(self.FREQS, None, None)
+        assert modes == {0}
+
+    def test_freq_nearest_match_within_tolerance(self):
+        """A value within 1 cm-1 of a mode matches that mode."""
+        modes = QRCGenerator._resolve_target_modes(self.FREQS, -536.0, None)
+        assert modes == {0}
+
+    def test_freq_no_match_raises(self):
+        with pytest.raises(QRCModeError, match="nearest"):
+            QRCGenerator._resolve_target_modes(self.FREQS, -500.0, None)
+
+    def test_freqnum_valid(self):
+        modes = QRCGenerator._resolve_target_modes(self.FREQS, None, 3)
+        assert modes == {2}
+
+    def test_freqnum_out_of_range_raises(self):
+        with pytest.raises(QRCModeError, match="out of range"):
+            QRCGenerator._resolve_target_modes(self.FREQS, None, 99)
+
+    def test_freqnum_zero_raises(self):
+        with pytest.raises(QRCModeError, match="out of range"):
+            QRCGenerator._resolve_target_modes(self.FREQS, None, 0)
 
 
 class TestMainModule:

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -1741,7 +1741,6 @@ class TestCLIFailureModes:
     missing files (1.3), unmatched --freq / out-of-range --freqnum (1.2).
     """
 
-    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.3: missing files currently exit 0 silently")
     def test_missing_file_exits_nonzero(self, tmp_path, monkeypatch, capsys):
         """A nonexistent input file should produce an error message and exit 1."""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -1734,6 +1734,54 @@ class TestQcoordMode:
         assert 'no imaginary frequencies: check for stability' in log_content
 
 
+class TestCLIFailureModes:
+    """Characterization tests for desired CLI failure behavior (ROADMAP 0.3).
+
+    Marked strict-xfail until the corresponding fixes land:
+    missing files (1.3), unmatched --freq / out-of-range --freqnum (1.2).
+    """
+
+    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.3: missing files currently exit 0 silently")
+    def test_missing_file_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        """A nonexistent input file should produce an error message and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr('sys.argv', ['pyqrc', str(tmp_path / 'does_not_exist.log')])
+        exit_code = main()
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert 'no such file' in captured.out
+
+    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.2: unmatched --freq currently writes an undisplaced input")
+    def test_unmatched_freq_errors_and_writes_nothing(self, g16_claisen_ts, temp_workdir, monkeypatch, capsys):
+        """--freq matching no normal mode should exit 1 and write no input file."""
+        shutil.copy(g16_claisen_ts, temp_workdir)
+        local_file = temp_workdir / g16_claisen_ts.name
+
+        # -123.45 cm-1 is not within tolerance of any mode in this file
+        monkeypatch.setattr('sys.argv', ['pyqrc', '-f', '-123.45', str(local_file)])
+        exit_code = main()
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert 'failed' in captured.out
+        assert not (temp_workdir / f"{local_file.stem}_QRC.com").exists()
+
+    @pytest.mark.xfail(strict=True, reason="ROADMAP 1.2: out-of-range --freqnum currently writes an undisplaced input")
+    def test_out_of_range_freqnum_errors_and_writes_nothing(self, g16_claisen_ts, temp_workdir, monkeypatch, capsys):
+        """--freqnum beyond the number of modes should exit 1 and write no input file."""
+        shutil.copy(g16_claisen_ts, temp_workdir)
+        local_file = temp_workdir / g16_claisen_ts.name
+
+        monkeypatch.setattr('sys.argv', ['pyqrc', '--freqnum', '99', str(local_file)])
+        exit_code = main()
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert 'failed' in captured.out
+        assert not (temp_workdir / f"{local_file.stem}_QRC.com").exists()
+
+
 class TestMainModule:
     """Tests for __main__.py entry point."""
 


### PR DESCRIPTION
Stacked on #12 (retarget to master after it merges). Implements roadmap Milestones 0 and 1.

## Changes

### Safety net (M0)
- **Characterization tests** for CLI failure modes, added as strict-xfail first, flipped as each fix landed (0.3)
- **New `package` CI job**: builds the wheel, asserts `pyqrc/run_g16.sh` is inside, installs it in a clean venv, and runs `pyqrc` end-to-end on a Gaussian example (0.2). This job fails on master today — that's the point.

### Critical fixes (M1)
- **Packaging** (1.1): the wheel previously shipped only the three `.py` files; `--qcoord` crashed in every pip install because `run_g16.sh` was missing. Package-data and MANIFEST.in pointed at a nonexistent `pyqrc/examples` path. Examples stay repo-only (decision D2).
- **File collection** (1.3): inputs now come from the argparse positional instead of a raw `sys.argv` re-scan. `pyqrc typo.log` now prints an error and exits 1 (previously: silent exit 0). Option values ending in `.log` are no longer swallowed as inputs.
- **`--freq`/`--freqnum` matching** (1.2): `--freq` now matches the nearest mode within 1 cm⁻¹ and **errors without writing any file** when nothing matches; `--freqnum` is range-checked. Previously, exact float equality meant a near-miss request silently wrote an **undisplaced** geometry while printing "processing".

### ⚠️ Behavior change (why this is v2.2.0)
Invocations that previously "succeeded" as silent no-ops (`--freq` near-misses, out-of-range `--freqnum`, missing files) now exit 1. New `QRCModeError` is exported from the package. **A PyPI release is needed after merge.**

## Verification
- [x] 110 tests pass, 0 xfail remaining (was 101)
- [x] pylint 9.98 (gate: 9.0)
- [x] Local end-to-end: built wheel → clean venv → `pyqrc acetaldehyde.log` creates input; `typo.log` → exit 1; `--freqnum 99` → clear error, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated package publishing to PyPI; CI now builds and validates distributables.

* **Bug Fixes**
  * Improved CLI behavior: frequency-based selection matches nearest mode within tolerance or errors if unmatched; out-of-range mode requests now error cleanly.
  * Packaging fixed to include required runtime script in distributions.

* **Documentation**
  * Updated CLI docs for --freq/--freqnum describing matching rules and error behavior.

* **Chores**
  * Version bumped to 2.2.0; CI workflows expanded to include package build/smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->