### PR TITLE
Fix publish workflow tag check for dynamic version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
         run: unzip -l dist/*.whl | grep "pyqrc/run_g16.sh"
       - name: Verify release tag matches package version
         run: |
-          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          # Version is dynamic (read from pyqrc/pyQRC.py), so take it from the built wheel
+          PKG_VERSION=$(basename dist/*.whl | cut -d- -f2)
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Release tag v$TAG_VERSION does not match pyproject.toml version $PKG_VERSION"
+            echo "Release tag v$TAG_VERSION does not match built package version $PKG_VERSION"
             exit 1
           fi
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The v2.2.0 release workflow failed with `KeyError: 'version'`: the tag check read `project.version` from pyproject.toml, but since #14 the version is dynamic (setuptools reads it from `pyqrc/pyQRC.py`). The check now derives the version from the built wheel filename, which is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process validation to ensure consistency between release tags and package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->