### PR TITLE
Fix 42-minute test-3.12 CI runs with coverage sysmon core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,14 @@ jobs:
             pip install -e ".[dev]"
       - run:
           name: Run tests with coverage
-          command: pytest --cov=pyqrc --cov-report=xml -v
+          command: |
+            # CPython 3.12's settrace is pathologically slow under coverage
+            # (gh-107674); the sys.monitoring core avoids it but only exists
+            # on 3.12+.
+            if python -c 'import sys; sys.exit(sys.version_info < (3, 12))'; then
+              export COVERAGE_CORE=sysmon
+            fi
+            pytest --cov=pyqrc --cov-report=xml -v
       - run:
           name: Upload coverage to Codecov (non-blocking)
           command: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,9 @@ Note (D3): per the README "ORCA 6 compatibility" section, cclib 1.8.1 is incompa
 CI-guarded, missing files and unmatched `--freq`/`--freqnum` fail loudly,
 dependencies bounded, version single-sourced, `QRCGenerator` split into
 parse/compute/write with a `write=False` library mode, and the suite runs
-with zero skips on release cclib. Version 2.2.0 needs a PyPI release.
+with zero skips on release cclib. **v2.2.0 was released to PyPI on
+2026-06-11** via the Trusted Publishing workflow (wheel verified to
+contain `run_g16.sh`).
 Remaining: 3.1 (`--qcoord` robustness, deferred per D1), 3.2 (Q-Chem
 `METHOD None` guard + unused `TERMINATION`), 3.4 (README/--help audit).
 


### PR DESCRIPTION
## Problem

Every `test-3.12` CircleCI job takes **~42 minutes** while all other matrix jobs (3.9, 3.10, 3.11, 3.13) finish in under 90 seconds. The tests all pass — the job is just pathologically slow, e.g. build 136: `115 passed in 2543.70s (0:42:23)`.

## Cause

CPython 3.12's `sys.settrace` became dramatically slower after the PEP 669 instrumentation rework (CPython gh-107674, coverage.py #1665), and coverage.py's default core uses it. 3.13 fixed the regression, which is why only the 3.12 cell of the matrix is affected. pyQRC's regex-heavy line-by-line log parsing is close to a worst case.

Reproduced locally on 3.12 with a 9-test subset:

| Run | Time |
|---|---|
| no coverage | 0.55 s |
| `--cov=pyqrc` (default core) | 121 s |
| `--cov=pyqrc` + `COVERAGE_CORE=sysmon` | 0.61 s |

## Fix

Export `COVERAGE_CORE=sysmon` in the test step so coverage uses the `sys.monitoring` core, guarded to Python 3.12+ only (`sysmon` errors on ≤3.11). The project uses line coverage only, which sysmon fully supports on 3.12.

Verified: full suite on 3.12 with `--cov --cov-report=xml` exactly as CI runs it → **117 passed in 3.6 s** with identical line-coverage results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI test configuration so coverage reporting runs with a Python-version guard for compatibility with older interpreters.
* **Documentation**
  * Roadmap updated to record v2.2.0 released to PyPI on 2026-06-11 and that the published wheel was verified to include the expected contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->