### PR TITLE
Milestone 3 leftovers: Q-Chem metadata guard, termination warning, README/--help audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ irc_comparison/**/*.com
 irc_comparison/**/*.qrc
 irc_comparison/irc/completed/
 irc_comparison/irc/failed/
+
+# Scratch directories created by the example notebooks
+examples/*/scratch/

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ python -m pyqrc [options] <output_file(s)>
 | `--name SUFFIX` | String appended to the filename for new input file(s). | `QRC` |
 | `-f, --freq FREQ` | Displace along the normal mode nearest this frequency (cm⁻¹); errors if no mode is within 1 cm⁻¹. | All imaginary |
 | `--freqnum FREQNUM` | Displace along frequency number N (from lowest); errors if N exceeds the number of modes. | All imaginary |
-| `--qcoord` | Automatic single point calculations along normal modes. | Disabled |
-| `--nummodes NUMMODES` | Number of modes for `--qcoord` calculations. | `all` |
+| `--qcoord` | **Deprecated, removal in 3.0.** Runs Gaussian single points along normal modes directly on the local machine (requires `g16` on `PATH`). Generate inputs with the default mode and submit them through your scheduler instead. | Disabled |
+| `--nummodes NUMMODES` | **Deprecated, removal in 3.0.** Number of modes for `--qcoord` calculations. | `all` |
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ python -m pyqrc [options] <output_file(s)>
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--amp AMPLITUDE` | Multiplier for the imaginary normal mode vector. Increase for larger displacements; use negative values for reverse direction. | `0.2` |
-| `--nproc N` | Number of processors requested in the new input file. | `1` |
-| `--mem NGB` | Memory requested in the new input file. Format: `XGB` or `X000MB`. | `4GB` |
-| `--route 'THEORY/BASIS'` | Route line for the new calculation. | Same as original |
-| `--name SUFFIX` | String appended to the filename for new input file(s). | `QRC` |
+| `--nproc NPROC` | Number of processors requested in the new input file. | `1` |
+| `--mem MEM` | Memory requested in the new input file. Format: `XGB` or `X000MB`. | `4GB` |
+| `--route ROUTE` | Route line for the new calculation, e.g. `'THEORY/BASIS opt'`. | Same as original |
 | `-q, --quiet` | Suppress verbose output (skips the `.qrc` summary file). | Verbose by default |
 | `--auto` | Only process files with imaginary frequencies, skip others. | Disabled |
-| `-f, --freq VALUE` | Displace along the normal mode nearest this frequency (cm⁻¹); errors if no mode is within 1 cm⁻¹. | All imaginary |
-| `--freqnum N` | Displace along frequency number N (from lowest); errors if N exceeds the number of modes. | All imaginary |
+| `--name SUFFIX` | String appended to the filename for new input file(s). | `QRC` |
+| `-f, --freq FREQ` | Displace along the normal mode nearest this frequency (cm⁻¹); errors if no mode is within 1 cm⁻¹. | All imaginary |
+| `--freqnum FREQNUM` | Displace along frequency number N (from lowest); errors if N exceeds the number of modes. | All imaginary |
 | `--qcoord` | Automatic single point calculations along normal modes. | Disabled |
-| `--nummodes N` | Number of modes for `--qcoord` calculations. | `all` |
+| `--nummodes NUMMODES` | Number of modes for `--qcoord` calculations. | `all` |
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ pyQRC generates the following files:
 
 ## Examples
 
+The input and output files for the examples below ship in the [examples](examples/) directory. Each format subdirectory ([g16](examples/g16/), [orca5](examples/orca5/), [orca6](examples/orca6/), [qchem](examples/qchem/)) also contains a runnable Jupyter notebook (`generate_qrc_inputs.ipynb`) that walks through generating QRC inputs from those files.
+
 ### Example 1: Remove an Unwanted Imaginary Frequency
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,9 +61,9 @@ Note (D3): per the README "ORCA 6 compatibility" section, cclib 1.8.1 is incompa
 | # | Task | Files | Acceptance criteria | Size | Risk | Deps |
 |---|------|-------|---------------------|------|------|------|
 | 3.1 | `--qcoord` robustness (only if D1 usage evidence appears): open the RUNIRC log once per run (not per file, which truncates it); try/except around per-file work; hoist `OutputData` out of the amplitude loop | `pyqrc/pyQRC.py` | Multi-file `--qcoord` keeps one complete log; one bad file doesn't abort the batch | M | Medium | 2.2 |
-| 3.2 | ~~Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`~~ (✅ done June 2026); error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; delete the unused `TERMINATION` attribute or use it to warn on abnormal termination | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
+| 3.2 ✅ | ~~Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`~~ (✅ done June 2026); error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; ~~delete~~ use `TERMINATION` to warn on abnormal Gaussian termination (it is public API per conventions) | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
 | 3.3 ✅ | CI/lint tidy-up: pylint workflow on `[push, pull_request]`; orphan `[tool.ruff.lint]` config deleted (pylint is the enforced linter); Python 3.13 added to both CI matrices and classifiers (D5) | `.github/workflows/pylint.yml`, `pyproject.toml`, `.circleci/config.yml` | PRs from forks get linted; no orphan tool config; 3.13 green | S | Low | — |
-| 3.4 | Audit the README options table against `pyqrc --help` (the `-v` → `-q` fix is already done) | `README.md` | Table matches `--help` verbatim | S | None | 1.2 |
+| 3.4 ✅ | Audit the README options table against `pyqrc --help` (the `-v` → `-q` fix is already done) | `README.md` | Table matches `--help` verbatim | S | None | 1.2 |
 
 ## Quick wins (all S, can be done immediately)
 
@@ -79,8 +79,8 @@ parse/compute/write with a `write=False` library mode, and the suite runs
 with zero skips on release cclib. **v2.2.0 was released to PyPI on
 2026-06-11** via the Trusted Publishing workflow (wheel verified to
 contain `run_g16.sh`).
-Remaining: 3.1 (`--qcoord` robustness, deferred per D1), 3.2 (Q-Chem
-`METHOD None` guard + unused `TERMINATION`), 3.4 (README/--help audit).
+Milestone 3 is also complete except 3.1 (`--qcoord` robustness), which
+stays deferred per D1 until there is evidence of `--qcoord` usage.
 
 ## Releasing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ unless overridden; tasks below assume them.
 
 | # | Question | Decision (proposed) | Rationale |
 |---|----------|---------------------|-----------|
-| D1 | Keep or deprecate `--qcoord`? | **Keep, fix packaging (1.1), defer robustness work (3.1)** until there is evidence of use. | Shipping `run_g16.sh` is a one-line fix; the absence of bug reports for a long-broken mode suggests low usage, so don't invest beyond that yet. |
+| D1 | Keep or deprecate `--qcoord`? | ~~Keep, fix packaging (1.1), defer robustness work (3.1) until there is evidence of use.~~ **Resolved 2026-06: deprecate.** Maintainer confirmed no known usage; `--qcoord`/`--nummodes` warn as deprecated in v2.3.0 and will be removed in 3.0. | The mode was unrunnable from pip installs for years with zero bug reports, and it runs Gaussian sequentially on the invoking machine — the wrong model for HPC users, who submit through a scheduler. |
 | D2 | Ship `examples/` in the wheel? | **No — repo-only.** Remove the dead `package-data`/`MANIFEST.in` references; optionally include examples in the sdist only. | They are test fixtures/docs (~MBs of QM output); installed users don't need them, and conftest already resolves repo-relative paths. |
 | D3 | cclib pinning policy | **Bound now: `cclib>=1.8.1,<2`; raise the floor to the first release containing the ORCA 6 fix when it ships**, then make the ORCA 6 example a tested fixture. | Matches the compatibility matrix the README already documents; an upper bound protects against the known master-branch Q-Chem regression pattern. |
 | D4 | `--freq` matching semantics | **Nearest mode within ±1 cm⁻¹ (configurable), print the matched mode; no match → error, no file, exit 1.** Release as **v2.2.0** with a release note. | Frequencies are reported to ~0.1 cm⁻¹; exact float equality can never be the intended UX. Previously "successful" no-op runs becoming errors is the point of the fix. |
@@ -60,7 +60,7 @@ Note (D3): per the README "ORCA 6 compatibility" section, cclib 1.8.1 is incompa
 
 | # | Task | Files | Acceptance criteria | Size | Risk | Deps |
 |---|------|-------|---------------------|------|------|------|
-| 3.1 | `--qcoord` robustness (only if D1 usage evidence appears): open the RUNIRC log once per run (not per file, which truncates it); try/except around per-file work; hoist `OutputData` out of the amplitude loop | `pyqrc/pyQRC.py` | Multi-file `--qcoord` keeps one complete log; one bad file doesn't abort the batch | M | Medium | 2.2 |
+| 3.1 ✖ | ~~`--qcoord` robustness~~ Superseded by D1 resolution (2026-06): `--qcoord` is deprecated in v2.3.0 and slated for removal in 3.0, so no robustness work will be done. Removal of the mode (and `run_g16.sh`, `g16_opt`, `run_irc`) is the 3.0 task. | `pyqrc/pyQRC.py` | — | — | — | — |
 | 3.2 ✅ | ~~Rename `BOHR_TO_ANGSTROM` → `ANGSTROM_TO_BOHR`~~ (✅ done June 2026); error out instead of writing `METHOD None`/`BASIS None` in Q-Chem inputs; ~~delete~~ use `TERMINATION` to warn on abnormal Gaussian termination (it is public API per conventions) | `pyqrc/pyQRC.py` | No misnamed constant; Q-Chem path errors clearly when metadata is missing | S | Low | — |
 | 3.3 ✅ | CI/lint tidy-up: pylint workflow on `[push, pull_request]`; orphan `[tool.ruff.lint]` config deleted (pylint is the enforced linter); Python 3.13 added to both CI matrices and classifiers (D5) | `.github/workflows/pylint.yml`, `pyproject.toml`, `.circleci/config.yml` | PRs from forks get linted; no orphan tool config; 3.13 green | S | Low | — |
 | 3.4 ✅ | Audit the README options table against `pyqrc --help` (the `-v` → `-q` fix is already done) | `README.md` | Table matches `--help` verbatim | S | None | 1.2 |
@@ -79,8 +79,10 @@ parse/compute/write with a `write=False` library mode, and the suite runs
 with zero skips on release cclib. **v2.2.0 was released to PyPI on
 2026-06-11** via the Trusted Publishing workflow (wheel verified to
 contain `run_g16.sh`).
-Milestone 3 is also complete except 3.1 (`--qcoord` robustness), which
-stays deferred per D1 until there is evidence of `--qcoord` usage.
+Milestone 3 is also resolved: 3.2–3.4 are done, and 3.1 was closed
+without action when D1 was resolved to deprecate `--qcoord` (v2.3.0
+warns; the mode is removed in 3.0). The roadmap is complete; the only
+follow-up is releasing v2.3.0 and, eventually, the 3.0 removal.
 
 ## Releasing
 

--- a/examples/g16/generate_qrc_inputs.ipynb
+++ b/examples/g16/generate_qrc_inputs.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e37e2491",
+   "metadata": {},
+   "source": [
+    "# Generating QRC inputs from Gaussian 16 frequency calculations\n",
+    "\n",
+    "pyQRC reads a completed frequency calculation and writes a new input file whose geometry has been displaced along one or more normal modes — Silva and Goodman's *Quick Reaction Coordinate* (QRC) approach. This notebook walks through the Gaussian 16 example files that ship in this directory.\n",
+    "\n",
+    "Requirements: `pip install pyqrc` (pulls in cclib and numpy).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e94f46a5",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "pyQRC writes its new input files next to the file it reads, so we copy the example outputs into a `scratch/` subdirectory and run everything there. The helper below invokes the same `pyqrc` command line you would use in a terminal or HPC batch script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ae51cc2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:51:54.054583Z",
+     "iopub.status.busy": "2026-06-11T14:51:54.054472Z",
+     "iopub.status.idle": "2026-06-11T14:51:54.068963Z",
+     "shell.execute_reply": "2026-06-11T14:51:54.068193Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "HERE = Path.cwd()                # this examples directory\n",
+    "SCRATCH = HERE / \"scratch\"\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir()\n",
+    "\n",
+    "for name in ['acetaldehyde.log', 'claisen_ts.log', 'planar_chex.log']:\n",
+    "    shutil.copy(HERE / name, SCRATCH / name)\n",
+    "\n",
+    "\n",
+    "def run_pyqrc(*args):\n",
+    "    \"\"\"Run the pyqrc command line inside the scratch directory.\"\"\"\n",
+    "    result = subprocess.run(\n",
+    "        [sys.executable, \"-m\", \"pyqrc\", *args],\n",
+    "        cwd=SCRATCH, capture_output=True, text=True,\n",
+    "    )\n",
+    "    print(result.stdout, end=\"\")\n",
+    "    if result.returncode != 0:\n",
+    "        print(result.stderr, end=\"\")\n",
+    "        raise RuntimeError(f\"pyqrc exited with code {result.returncode}\")\n",
+    "\n",
+    "\n",
+    "def show(filename, n=40):\n",
+    "    \"\"\"Print up to n lines of a file in the scratch directory.\"\"\"\n",
+    "    lines = (SCRATCH / filename).read_text().splitlines()\n",
+    "    print(\"\\n\".join(lines[:n]))\n",
+    "    if len(lines) > n:\n",
+    "        print(f\"... ({len(lines) - n} more lines)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e6a46a7",
+   "metadata": {},
+   "source": [
+    "## Example 1: remove an unwanted imaginary frequency\n",
+    "\n",
+    "This acetaldehyde optimization inadvertently produced a saddle point — it has one small imaginary frequency. By default pyQRC displaces along **all** imaginary modes, which is exactly what we want here: the displaced geometry breaks the symmetry of the saddle point, and re-optimizing it gives the true minimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "84df672b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:51:54.071665Z",
+     "iopub.status.busy": "2026-06-11T14:51:54.071502Z",
+     "iopub.status.idle": "2026-06-11T14:51:56.814272Z",
+     "shell.execute_reply": "2026-06-11T14:51:56.813620Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   acetaldehyde.log had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"acetaldehyde.log\", \"--nproc\", \"4\", \"--mem\", \"8GB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a95b79b3",
+   "metadata": {},
+   "source": [
+    "That wrote two files: `acetaldehyde_QRC.com` (the new, displaced input — ready to submit) and `acetaldehyde_QRC.qrc` (a human-readable summary of the frequencies and the displacement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ca943c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:51:56.817671Z",
+     "iopub.status.busy": "2026-06-11T14:51:56.817369Z",
+     "iopub.status.idle": "2026-06-11T14:51:56.820530Z",
+     "shell.execute_reply": "2026-06-11T14:51:56.820117Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%chk=acetaldehyde_QRC.chk\n",
+      "%nproc=4\n",
+      "%mem=8GB\n",
+      "# opt freq M062X/6-31G*\n",
+      "\n",
+      "acetaldehyde_QRC\n",
+      "\n",
+      "0 1\n",
+      " C  -0.24032600   0.41382900  -0.01800100\n",
+      " O  -1.21931300  -0.28867900   0.01400000\n",
+      " H  -0.34388700   1.51866800  -0.08199900\n",
+      " C   1.16822300  -0.13555600   0.00399900\n",
+      " H   1.91748100   0.65773200   0.10393500\n",
+      " H   1.26478600  -0.85024500   0.83156500\n",
+      " H   1.34874500  -0.68635700  -0.93149200\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.com\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7b8db51",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:51:56.822075Z",
+     "iopub.status.busy": "2026-06-11T14:51:56.821984Z",
+     "iopub.status.idle": "2026-06-11T14:51:56.824391Z",
+     "shell.execute_reply": "2026-06-11T14:51:56.823934Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " pyQRC - a quick alternative to IRC calculations\n",
+      " version: 2.3.0 / author: Robert Paton / email: robert.paton@colostate.edu\n",
+      " Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;\n",
+      " Tet. Lett. 2005, 46, 2067-2069.\n",
+      "\n",
+      "                -----ORIGINAL GEOMETRY------\n",
+      "                       X         Y         Z\n",
+      "   C           -0.240326  0.413829 -0.000001\n",
+      "   O           -1.219313 -0.288679  0.000000\n",
+      "   H           -0.343887  1.518668  0.000001\n",
+      "   C            1.168223 -0.135556 -0.000001\n",
+      "   H            1.917481  0.657732 -0.000065\n",
+      "   H            1.306786 -0.768245  0.881565\n",
+      "   H            1.306745 -0.768357 -0.881492\n",
+      "\n",
+      "                ----HARMONIC FREQUENCIES----\n",
+      "                    Freq  Red mass   F const\n",
+      "               -164.6818    1.1913    0.0190\n",
+      "                507.9671    2.6617    0.4046\n",
+      "                761.1498    1.1728    0.4003\n",
+      "                952.1134    2.1851    1.1671\n",
+      "               1115.6721    1.9956    1.4635\n",
+      "               1147.0025    1.7207    1.3338\n",
+      "               1399.7430    1.2161    1.4038\n",
+      "... (23 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.qrc\", n=24)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cba657b1",
+   "metadata": {},
+   "source": [
+    "## Example 2: map a reaction coordinate (the namesake QRC)\n",
+    "\n",
+    "For a transition state — here a Claisen rearrangement — the quick alternative to an IRC is two displaced inputs: one along the imaginary mode (`--amp 0.3`) and one in the reverse direction (`--amp -0.3`). Optimizing both gives the reactant and product the TS connects. The benchmark in the README found an amplitude of **0.3** performs best, hence the values used here; `--name` controls the suffix of the generated files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ef91681b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:51:56.825797Z",
+     "iopub.status.busy": "2026-06-11T14:51:56.825699Z",
+     "iopub.status.idle": "2026-06-11T14:52:01.644822Z",
+     "shell.execute_reply": "2026-06-11T14:52:01.643073Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   claisen_ts.log had 1 imaginary frequencies: processed\n",
+      "o   claisen_ts.log had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"claisen_ts.log\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"0.3\", \"--name\", \"QRCF\")\n",
+    "run_pyqrc(\"claisen_ts.log\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"-0.3\", \"--name\", \"QRCR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f69738a4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:01.646770Z",
+     "iopub.status.busy": "2026-06-11T14:52:01.646620Z",
+     "iopub.status.idle": "2026-06-11T14:52:01.650075Z",
+     "shell.execute_reply": "2026-06-11T14:52:01.649349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%chk=claisen_ts_QRCF.chk\n",
+      "%nproc=4\n",
+      "%mem=8GB\n",
+      "# opt(ts,calcfc,noeigentest) freq=noraman wb97xd/6-31+G*\n",
+      "\n",
+      "claisen_ts_QRCF\n",
+      "\n",
+      "0 1\n",
+      " C  -1.37087800   0.76347400  -0.26922500\n",
+      " C  -1.24135200  -0.56957300   0.25254000\n",
+      " O  -0.51557700  -1.40777800  -0.27025500\n",
+      " C   1.45620400  -0.77049900   0.20597600\n",
+      " C   1.33983300   0.47219400  -0.29750300\n",
+      " C   0.42652100   1.41099800   0.30589200\n",
+      "... (9 more lines)\n",
+      "============================================================\n",
+      "%chk=claisen_ts_QRCR.chk\n",
+      "%nproc=4\n",
+      "%mem=8GB\n",
+      "# opt(ts,calcfc,noeigentest) freq=noraman wb97xd/6-31+G*\n",
+      "\n",
+      "claisen_ts_QRCR\n",
+      "\n",
+      "0 1\n",
+      " C  -1.57487800   0.64347400  -0.31722500\n",
+      " C  -1.24735200  -0.51557300   0.25854000\n",
+      " O  -0.29957700  -1.34777800  -0.23425500\n",
+      " C   1.17420400  -0.87849900   0.15797600\n",
+      " C   1.32183300   0.51419400  -0.29750300\n",
+      " C   0.66052100   1.47699800   0.34789200\n",
+      "... (9 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"claisen_ts_QRCF.com\", n=14)\n",
+    "print(\"=\" * 60)\n",
+    "show(\"claisen_ts_QRCR.com\", n=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb70bbb5",
+   "metadata": {},
+   "source": [
+    "## Example 3: conformational sampling via specific modes\n",
+    "\n",
+    "Planar cyclohexane is a third-order saddle point with three imaginary frequencies. Instead of displacing along all of them at once, `--freqnum N` picks a single (1-indexed, sorted from lowest) mode. Optimizing the two inputs below yields different minima: mode 1 leads to the chair, mode 3 to the twist-boat — a simple form of conformational sampling. (`--freq <value>` similarly picks the mode nearest a wavenumber in cm⁻¹.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "aa52847b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:01.652400Z",
+     "iopub.status.busy": "2026-06-11T14:52:01.652173Z",
+     "iopub.status.idle": "2026-06-11T14:52:06.231102Z",
+     "shell.execute_reply": "2026-06-11T14:52:06.230426Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   planar_chex.log was distorted along freq #1\n",
+      "o   planar_chex.log was distorted along freq #3\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"planar_chex.log\", \"--nproc\", \"4\", \"--freqnum\", \"1\", \"--name\", \"mode1\")\n",
+    "run_pyqrc(\"planar_chex.log\", \"--nproc\", \"4\", \"--freqnum\", \"3\", \"--name\", \"mode3\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "879d2032",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:06.232968Z",
+     "iopub.status.busy": "2026-06-11T14:52:06.232824Z",
+     "iopub.status.idle": "2026-06-11T14:52:06.236117Z",
+     "shell.execute_reply": "2026-06-11T14:52:06.235659Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%chk=planar_chex_mode1.chk\n",
+      "%nproc=4\n",
+      "%mem=4GB\n",
+      "# symm=loose opt b3lyp/6-31G* freq\n",
+      "\n",
+      "planar_chex_mode1\n",
+      "\n",
+      "0 1\n",
+      " C   0.16785800   1.54628900   0.01792900\n",
+      " C   1.42312600   0.62775200  -0.01724200\n",
+      "... (17 more lines)\n",
+      "============================================================\n",
+      "%chk=planar_chex_mode3.chk\n",
+      "%nproc=4\n",
+      "%mem=4GB\n",
+      "# symm=loose opt b3lyp/6-31G* freq\n",
+      "\n",
+      "planar_chex_mode3\n",
+      "\n",
+      "0 1\n",
+      " C   0.16785800   1.54628900   0.02592900\n",
+      " C   1.42312600   0.62775200  -0.01924200\n",
+      "... (17 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"planar_chex_mode1.com\", n=10)\n",
+    "print(\"=\" * 60)\n",
+    "show(\"planar_chex_mode3.com\", n=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d63430a",
+   "metadata": {},
+   "source": [
+    "## Using the Python API instead of the CLI\n",
+    "\n",
+    "The same machinery is importable. `QRCGenerator` parses the output, computes the displaced geometry, and (unless `write=False`) writes the files in one go. With `write=False` you can inspect the displacement before committing anything to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b6df80c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:06.237636Z",
+     "iopub.status.busy": "2026-06-11T14:52:06.237550Z",
+     "iopub.status.idle": "2026-06-11T14:52:08.258970Z",
+     "shell.execute_reply": "2026-06-11T14:52:08.258370Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imaginary frequencies (cm-1): [-589.7505]\n",
+      "Mass-weighted displacement from the TS: 1.7753 bohr amu^1/2\n",
+      "Displaced geometry has clashing atoms: False\n",
+      "\n",
+      "Atoms that move the most:\n",
+      "  atom  4 (C ) moved 0.153 Angstrom\n",
+      "  atom  6 (C ) moved 0.123 Angstrom\n",
+      "  atom  1 (C ) moved 0.121 Angstrom\n",
+      "  atom  3 (O ) moved 0.114 Angstrom\n",
+      "  atom  7 (H ) moved 0.098 Angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from pyqrc import QRCGenerator\n",
+    "\n",
+    "qrc = QRCGenerator(\n",
+    "    file=str(SCRATCH / \"claisen_ts.log\"),\n",
+    "    amplitude=0.3,\n",
+    "    nproc=4,\n",
+    "    mem=\"8GB\",\n",
+    "    route=None,     # None clones the route/keywords from the original job\n",
+    "    verbose=False,  # skip the .qrc summary file\n",
+    "    suffix=\"API\",\n",
+    "    val=None,       # or displace along the mode nearest this frequency (cm-1)\n",
+    "    num=None,       # or along this 1-indexed mode number\n",
+    "    write=False,    # compute only; no files are written\n",
+    ")\n",
+    "\n",
+    "freqs = np.asarray(qrc.FREQS)\n",
+    "print(\"Imaginary frequencies (cm-1):\", freqs[freqs < 0.0])\n",
+    "print(f\"Mass-weighted displacement from the TS: {qrc.MW_DISTANCE:.4f} bohr amu^1/2\")\n",
+    "print(\"Displaced geometry has clashing atoms:\", qrc.OVERLAPPED)\n",
+    "print()\n",
+    "\n",
+    "per_atom = np.linalg.norm(qrc.NEW_CARTESIAN - qrc.CARTESIAN, axis=1)\n",
+    "print(\"Atoms that move the most:\")\n",
+    "for i in np.argsort(per_atom)[::-1][:5]:\n",
+    "    print(f\"  atom {i + 1:>2} ({qrc.ATOMTYPES[i]:<2}) moved {per_atom[i]:.3f} Angstrom\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8b5cdb2",
+   "metadata": {},
+   "source": [
+    "## Where the files went\n",
+    "\n",
+    "Everything generated above is in the `scratch/` subdirectory (ignored by git) — delete it when you are done. In real use you would submit the new input file (`*.com`) to your scheduler and optimize.\n",
+    "\n",
+    "See the [project README](../../README.md) for the full option list and for the IRC-comparison benchmark behind the recommended amplitude of 0.3.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/orca5/generate_qrc_inputs.ipynb
+++ b/examples/orca5/generate_qrc_inputs.ipynb
@@ -1,0 +1,402 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "153d5c3b",
+   "metadata": {},
+   "source": [
+    "# Generating QRC inputs from ORCA 5 frequency calculations\n",
+    "\n",
+    "pyQRC reads a completed frequency calculation and writes a new input file whose geometry has been displaced along one or more normal modes — Silva and Goodman's *Quick Reaction Coordinate* (QRC) approach. This notebook walks through the ORCA 5 example files that ship in this directory.\n",
+    "\n",
+    "Requirements: `pip install pyqrc` (pulls in cclib and numpy).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f841e50f",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "pyQRC writes its new input files next to the file it reads, so we copy the example outputs into a `scratch/` subdirectory and run everything there. The helper below invokes the same `pyqrc` command line you would use in a terminal or HPC batch script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "00ba10c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:11.618364Z",
+     "iopub.status.busy": "2026-06-11T14:52:11.618099Z",
+     "iopub.status.idle": "2026-06-11T14:52:11.629414Z",
+     "shell.execute_reply": "2026-06-11T14:52:11.628175Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "HERE = Path.cwd()                # this examples directory\n",
+    "SCRATCH = HERE / \"scratch\"\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir()\n",
+    "\n",
+    "for name in ['acetaldehyde.out', 'claisen_ts.out']:\n",
+    "    shutil.copy(HERE / name, SCRATCH / name)\n",
+    "\n",
+    "\n",
+    "def run_pyqrc(*args):\n",
+    "    \"\"\"Run the pyqrc command line inside the scratch directory.\"\"\"\n",
+    "    result = subprocess.run(\n",
+    "        [sys.executable, \"-m\", \"pyqrc\", *args],\n",
+    "        cwd=SCRATCH, capture_output=True, text=True,\n",
+    "    )\n",
+    "    print(result.stdout, end=\"\")\n",
+    "    if result.returncode != 0:\n",
+    "        print(result.stderr, end=\"\")\n",
+    "        raise RuntimeError(f\"pyqrc exited with code {result.returncode}\")\n",
+    "\n",
+    "\n",
+    "def show(filename, n=40):\n",
+    "    \"\"\"Print up to n lines of a file in the scratch directory.\"\"\"\n",
+    "    lines = (SCRATCH / filename).read_text().splitlines()\n",
+    "    print(\"\\n\".join(lines[:n]))\n",
+    "    if len(lines) > n:\n",
+    "        print(f\"... ({len(lines) - n} more lines)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77ebced7",
+   "metadata": {},
+   "source": [
+    "## Example 1: remove an unwanted imaginary frequency\n",
+    "\n",
+    "This acetaldehyde optimization inadvertently produced a saddle point — it has one small imaginary frequency. By default pyQRC displaces along **all** imaginary modes, which is exactly what we want here: the displaced geometry breaks the symmetry of the saddle point, and re-optimizing it gives the true minimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3f2c9f7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:11.631927Z",
+     "iopub.status.busy": "2026-06-11T14:52:11.631761Z",
+     "iopub.status.idle": "2026-06-11T14:52:13.740929Z",
+     "shell.execute_reply": "2026-06-11T14:52:13.740209Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   acetaldehyde.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"acetaldehyde.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fb4856a",
+   "metadata": {},
+   "source": [
+    "That wrote two files: `acetaldehyde_QRC.inp` (the new, displaced input — ready to submit) and `acetaldehyde_QRC.qrc` (a human-readable summary of the frequencies and the displacement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a1b14f47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:13.742804Z",
+     "iopub.status.busy": "2026-06-11T14:52:13.742633Z",
+     "iopub.status.idle": "2026-06-11T14:52:13.746217Z",
+     "shell.execute_reply": "2026-06-11T14:52:13.745571Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "! M062X D3Zero def2-TZVP Opt Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# acetaldehyde_QRC\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C   0.23613500   0.41153820  -0.01860840\n",
+      " O   1.21078120  -0.28630260   0.01507700\n",
+      " H   0.34334620   1.51367680  -0.08137280\n",
+      " C  -1.16782600  -0.13487600   0.00507740\n",
+      " H  -1.91392200   0.65654420   0.10356580\n",
+      " H  -1.34213100  -0.68217640  -0.92940560\n",
+      " H  -1.26209480  -0.84900940   0.82949880\n",
+      "*\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.inp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "75098cc8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:13.747801Z",
+     "iopub.status.busy": "2026-06-11T14:52:13.747688Z",
+     "iopub.status.idle": "2026-06-11T14:52:13.751630Z",
+     "shell.execute_reply": "2026-06-11T14:52:13.750718Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " pyQRC - a quick alternative to IRC calculations\n",
+      " version: 2.3.0 / author: Robert Paton / email: robert.paton@colostate.edu\n",
+      " Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;\n",
+      " Tet. Lett. 2005, 46, 2067-2069.\n",
+      "\n",
+      "                -----ORIGINAL GEOMETRY------\n",
+      "                       X         Y         Z\n",
+      "   C            0.236135  0.411539  0.000002\n",
+      "   O            1.210781 -0.286303  0.000021\n",
+      "   H            0.343347  1.513679 -0.000026\n",
+      "   C           -1.167826 -0.134876  0.000003\n",
+      "   H           -1.913926  0.656550  0.000080\n",
+      "   H           -1.302134 -0.765529 -0.879503\n",
+      "   H           -1.302086 -0.765667  0.879416\n",
+      "\n",
+      "                ----HARMONIC FREQUENCIES----\n",
+      "                    Freq  Red mass   F const\n",
+      "               -200.7700    0.0000    0.0000\n",
+      "                511.7500    0.0000    0.0000\n",
+      "                743.3100    0.0000    0.0000\n",
+      "                945.2100    0.0000    0.0000\n",
+      "               1101.2000    0.0000    0.0000\n",
+      "               1140.6100    0.0000    0.0000\n",
+      "               1372.7200    0.0000    0.0000\n",
+      "... (23 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.qrc\", n=24)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce0eba20",
+   "metadata": {},
+   "source": [
+    "## Example 2: map a reaction coordinate (the namesake QRC)\n",
+    "\n",
+    "For a transition state — here a Claisen rearrangement — the quick alternative to an IRC is two displaced inputs: one along the imaginary mode (`--amp 0.3`) and one in the reverse direction (`--amp -0.3`). Optimizing both gives the reactant and product the TS connects. The benchmark in the README found an amplitude of **0.3** performs best, hence the values used here; `--name` controls the suffix of the generated files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9387052d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:13.754214Z",
+     "iopub.status.busy": "2026-06-11T14:52:13.754068Z",
+     "iopub.status.idle": "2026-06-11T14:52:18.299282Z",
+     "shell.execute_reply": "2026-06-11T14:52:18.298385Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n",
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"0.3\", \"--name\", \"QRCF\")\n",
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"-0.3\", \"--name\", \"QRCR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "14062f34",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:18.302551Z",
+     "iopub.status.busy": "2026-06-11T14:52:18.302174Z",
+     "iopub.status.idle": "2026-06-11T14:52:18.307390Z",
+     "shell.execute_reply": "2026-06-11T14:52:18.306501Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "! wB97X-D3 def2-SVP OptTS Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# claisen_ts_QRCF\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C  -1.30253020   0.85112420  -0.26100730\n",
+      " C  -1.26730120  -0.49404660   0.26503650\n",
+      " O  -0.59292170  -1.36580820  -0.24281670\n",
+      " C   1.40418360  -0.85803340   0.19334720\n",
+      " C   1.36552830   0.38861970  -0.30489760\n",
+      " C   0.49705980   1.38110140   0.29484280\n",
+      " H  -2.02253680   1.54681610   0.18829810\n",
+      "... (8 more lines)\n",
+      "============================================================\n",
+      "! wB97X-D3 def2-SVP OptTS Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# claisen_ts_QRCR\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C  -1.52173780   0.73999580  -0.30649870\n",
+      " C  -1.27089880  -0.43735740   0.26926350\n",
+      " O  -0.37508630  -1.32302580  -0.21404730\n",
+      " C   1.11507240  -0.94904260   0.15396680\n",
+      " C   1.34987370   0.43435230  -0.30356440\n",
+      " C   0.74243220   1.43125060   0.33650320\n",
+      " H  -2.18287120   1.47038990   0.16658590\n",
+      "... (8 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"claisen_ts_QRCF.inp\", n=14)\n",
+    "print(\"=\" * 60)\n",
+    "show(\"claisen_ts_QRCR.inp\", n=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caa1481b",
+   "metadata": {},
+   "source": [
+    "## Using the Python API instead of the CLI\n",
+    "\n",
+    "The same machinery is importable. `QRCGenerator` parses the output, computes the displaced geometry, and (unless `write=False`) writes the files in one go. With `write=False` you can inspect the displacement before committing anything to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c2c5381a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:18.311118Z",
+     "iopub.status.busy": "2026-06-11T14:52:18.310954Z",
+     "iopub.status.idle": "2026-06-11T14:52:20.456578Z",
+     "shell.execute_reply": "2026-06-11T14:52:20.455429Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imaginary frequencies (cm-1): [-633.34]\n",
+      "Mass-weighted displacement from the TS: 1.7927 bohr amu^1/2\n",
+      "Displaced geometry has clashing atoms: False\n",
+      "\n",
+      "Atoms that move the most:\n",
+      "  atom  4 (C ) moved 0.153 Angstrom\n",
+      "  atom  6 (C ) moved 0.127 Angstrom\n",
+      "  atom  1 (C ) moved 0.125 Angstrom\n",
+      "  atom  3 (O ) moved 0.112 Angstrom\n",
+      "  atom  7 (H ) moved 0.089 Angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from pyqrc import QRCGenerator\n",
+    "\n",
+    "qrc = QRCGenerator(\n",
+    "    file=str(SCRATCH / \"claisen_ts.out\"),\n",
+    "    amplitude=0.3,\n",
+    "    nproc=4,\n",
+    "    mem=\"8GB\",\n",
+    "    route=None,     # None clones the route/keywords from the original job\n",
+    "    verbose=False,  # skip the .qrc summary file\n",
+    "    suffix=\"API\",\n",
+    "    val=None,       # or displace along the mode nearest this frequency (cm-1)\n",
+    "    num=None,       # or along this 1-indexed mode number\n",
+    "    write=False,    # compute only; no files are written\n",
+    ")\n",
+    "\n",
+    "freqs = np.asarray(qrc.FREQS)\n",
+    "print(\"Imaginary frequencies (cm-1):\", freqs[freqs < 0.0])\n",
+    "print(f\"Mass-weighted displacement from the TS: {qrc.MW_DISTANCE:.4f} bohr amu^1/2\")\n",
+    "print(\"Displaced geometry has clashing atoms:\", qrc.OVERLAPPED)\n",
+    "print()\n",
+    "\n",
+    "per_atom = np.linalg.norm(qrc.NEW_CARTESIAN - qrc.CARTESIAN, axis=1)\n",
+    "print(\"Atoms that move the most:\")\n",
+    "for i in np.argsort(per_atom)[::-1][:5]:\n",
+    "    print(f\"  atom {i + 1:>2} ({qrc.ATOMTYPES[i]:<2}) moved {per_atom[i]:.3f} Angstrom\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8a512a9",
+   "metadata": {},
+   "source": [
+    "## Where the files went\n",
+    "\n",
+    "Everything generated above is in the `scratch/` subdirectory (ignored by git) — delete it when you are done. In real use you would submit the new input file (`*.inp`) to your scheduler and optimize.\n",
+    "\n",
+    "See the [project README](../../README.md) for the full option list and for the IRC-comparison benchmark behind the recommended amplitude of 0.3.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/orca6/generate_qrc_inputs.ipynb
+++ b/examples/orca6/generate_qrc_inputs.ipynb
@@ -1,0 +1,409 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "48bbb69f",
+   "metadata": {},
+   "source": [
+    "# Generating QRC inputs from ORCA 6 frequency calculations\n",
+    "\n",
+    "pyQRC reads a completed frequency calculation and writes a new input file whose geometry has been displaced along one or more normal modes — Silva and Goodman's *Quick Reaction Coordinate* (QRC) approach. This notebook walks through the ORCA 6 example files that ship in this directory.\n",
+    "\n",
+    "Requirements: `pip install pyqrc` (pulls in cclib and numpy).\n",
+    "\n",
+    "> **Note:** parsing ORCA 6 outputs needs a newer cclib than the current PyPI release (1.8.1). Install cclib from GitHub master alongside pyQRC:\n",
+    "> ```\n",
+    "> pip install pyqrc\n",
+    "> pip install --upgrade git+https://github.com/cclib/cclib.git\n",
+    "> ```\n",
+    "> See the README “ORCA 6 compatibility” section.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b38b567f",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "pyQRC writes its new input files next to the file it reads, so we copy the example outputs into a `scratch/` subdirectory and run everything there. The helper below invokes the same `pyqrc` command line you would use in a terminal or HPC batch script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8bf67bd4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:23.607572Z",
+     "iopub.status.busy": "2026-06-11T14:52:23.607451Z",
+     "iopub.status.idle": "2026-06-11T14:52:23.620015Z",
+     "shell.execute_reply": "2026-06-11T14:52:23.618653Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "HERE = Path.cwd()                # this examples directory\n",
+    "SCRATCH = HERE / \"scratch\"\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir()\n",
+    "\n",
+    "for name in ['acetaldehyde.out', 'claisen_ts.out']:\n",
+    "    shutil.copy(HERE / name, SCRATCH / name)\n",
+    "\n",
+    "\n",
+    "def run_pyqrc(*args):\n",
+    "    \"\"\"Run the pyqrc command line inside the scratch directory.\"\"\"\n",
+    "    result = subprocess.run(\n",
+    "        [sys.executable, \"-m\", \"pyqrc\", *args],\n",
+    "        cwd=SCRATCH, capture_output=True, text=True,\n",
+    "    )\n",
+    "    print(result.stdout, end=\"\")\n",
+    "    if result.returncode != 0:\n",
+    "        print(result.stderr, end=\"\")\n",
+    "        raise RuntimeError(f\"pyqrc exited with code {result.returncode}\")\n",
+    "\n",
+    "\n",
+    "def show(filename, n=40):\n",
+    "    \"\"\"Print up to n lines of a file in the scratch directory.\"\"\"\n",
+    "    lines = (SCRATCH / filename).read_text().splitlines()\n",
+    "    print(\"\\n\".join(lines[:n]))\n",
+    "    if len(lines) > n:\n",
+    "        print(f\"... ({len(lines) - n} more lines)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2d3350b",
+   "metadata": {},
+   "source": [
+    "## Example 1: remove an unwanted imaginary frequency\n",
+    "\n",
+    "This acetaldehyde optimization inadvertently produced a saddle point — it has one small imaginary frequency. By default pyQRC displaces along **all** imaginary modes, which is exactly what we want here: the displaced geometry breaks the symmetry of the saddle point, and re-optimizing it gives the true minimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9318f99d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:23.622008Z",
+     "iopub.status.busy": "2026-06-11T14:52:23.621856Z",
+     "iopub.status.idle": "2026-06-11T14:52:25.779361Z",
+     "shell.execute_reply": "2026-06-11T14:52:25.778449Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   acetaldehyde.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"acetaldehyde.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3aad306c",
+   "metadata": {},
+   "source": [
+    "That wrote two files: `acetaldehyde_QRC.inp` (the new, displaced input — ready to submit) and `acetaldehyde_QRC.qrc` (a human-readable summary of the frequencies and the displacement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d851e597",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:25.781452Z",
+     "iopub.status.busy": "2026-06-11T14:52:25.781310Z",
+     "iopub.status.idle": "2026-06-11T14:52:25.784927Z",
+     "shell.execute_reply": "2026-06-11T14:52:25.784166Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "! M062X D3Zero def2-TZVP Opt Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# acetaldehyde_QRC\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C   0.23618700   0.41131180  -0.01736280\n",
+      " O   1.21130820  -0.28571240   0.01478220\n",
+      " H   0.34318860   1.51327080  -0.08253560\n",
+      " C  -1.16787080  -0.13484440   0.00549760\n",
+      " H  -1.91375560   0.65682480   0.10307740\n",
+      " H  -1.34180580  -0.68144120  -0.92950220\n",
+      " H  -1.26293380  -0.85012200   0.82905400\n",
+      "*\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.inp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8fb650ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:25.787729Z",
+     "iopub.status.busy": "2026-06-11T14:52:25.787606Z",
+     "iopub.status.idle": "2026-06-11T14:52:25.790672Z",
+     "shell.execute_reply": "2026-06-11T14:52:25.789843Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " pyQRC - a quick alternative to IRC calculations\n",
+      " version: 2.3.0 / author: Robert Paton / email: robert.paton@colostate.edu\n",
+      " Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;\n",
+      " Tet. Lett. 2005, 46, 2067-2069.\n",
+      "\n",
+      "                -----ORIGINAL GEOMETRY------\n",
+      "                       X         Y         Z\n",
+      "   C            0.236194  0.411275  0.001351\n",
+      "   O            1.211305 -0.285687 -0.000292\n",
+      "   H            0.343212  1.513360 -0.001250\n",
+      "   C           -1.167871 -0.134852  0.000269\n",
+      "   H           -1.913641  0.656933  0.000318\n",
+      "   H           -1.302003 -0.765268 -0.879506\n",
+      "   H           -1.302906 -0.766368  0.879104\n",
+      "\n",
+      "                ----HARMONIC FREQUENCIES----\n",
+      "                    Freq  Red mass   F const\n",
+      "               -190.7400    0.0000    0.0000\n",
+      "                515.1100    0.0000    0.0000\n",
+      "                752.4700    0.0000    0.0000\n",
+      "                946.0200    0.0000    0.0000\n",
+      "               1103.5600    0.0000    0.0000\n",
+      "               1144.7100    0.0000    0.0000\n",
+      "               1377.0100    0.0000    0.0000\n",
+      "... (23 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.qrc\", n=24)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fa55c6a",
+   "metadata": {},
+   "source": [
+    "## Example 2: map a reaction coordinate (the namesake QRC)\n",
+    "\n",
+    "For a transition state — here a Claisen rearrangement — the quick alternative to an IRC is two displaced inputs: one along the imaginary mode (`--amp 0.3`) and one in the reverse direction (`--amp -0.3`). Optimizing both gives the reactant and product the TS connects. The benchmark in the README found an amplitude of **0.3** performs best, hence the values used here; `--name` controls the suffix of the generated files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4dadda75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:25.792230Z",
+     "iopub.status.busy": "2026-06-11T14:52:25.792145Z",
+     "iopub.status.idle": "2026-06-11T14:52:30.365504Z",
+     "shell.execute_reply": "2026-06-11T14:52:30.364274Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n",
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"0.3\", \"--name\", \"QRCF\")\n",
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"-0.3\", \"--name\", \"QRCR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "15684a63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:30.367559Z",
+     "iopub.status.busy": "2026-06-11T14:52:30.367421Z",
+     "iopub.status.idle": "2026-06-11T14:52:30.370893Z",
+     "shell.execute_reply": "2026-06-11T14:52:30.370229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "! wB97X-D3 def2-SVP OptTS Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# claisen_ts_QRCF\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C  -1.29903370   0.85232150  -0.25975320\n",
+      " C  -1.26552080  -0.49517880   0.26246170\n",
+      " O  -0.59069340  -1.36466300  -0.24766300\n",
+      " C   1.40091060  -0.85824280   0.19416940\n",
+      " C   1.36559110   0.38855000  -0.30341050\n",
+      " C   0.49374640   1.38058420   0.29401600\n",
+      " H  -2.02027740   1.54638730   0.19052240\n",
+      "... (8 more lines)\n",
+      "============================================================\n",
+      "! wB97X-D3 def2-SVP OptTS Freq\n",
+      " %pal nprocs 4 end\n",
+      " %maxcore 8192\n",
+      "\n",
+      "# claisen_ts_QRCR\n",
+      "\n",
+      "* xyz 0 1\n",
+      " C  -1.51985230   0.74088050  -0.30567480\n",
+      " C  -1.26975920  -0.43770720   0.26734630\n",
+      " O  -0.37303860  -1.32175700  -0.21863500\n",
+      " C   1.11343740  -0.94951720   0.15407860\n",
+      " C   1.35043090   0.43425800  -0.30220150\n",
+      " C   0.73957360   1.43039980   0.33589600\n",
+      " H  -2.18053260   1.47074470   0.16898360\n",
+      "... (8 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"claisen_ts_QRCF.inp\", n=14)\n",
+    "print(\"=\" * 60)\n",
+    "show(\"claisen_ts_QRCR.inp\", n=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8424ceea",
+   "metadata": {},
+   "source": [
+    "## Using the Python API instead of the CLI\n",
+    "\n",
+    "The same machinery is importable. `QRCGenerator` parses the output, computes the displaced geometry, and (unless `write=False`) writes the files in one go. With `write=False` you can inspect the displacement before committing anything to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9a169305",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T14:52:30.372198Z",
+     "iopub.status.busy": "2026-06-11T14:52:30.372117Z",
+     "iopub.status.idle": "2026-06-11T14:52:32.436793Z",
+     "shell.execute_reply": "2026-06-11T14:52:32.436129Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imaginary frequencies (cm-1): [-636.62]\n",
+      "Mass-weighted displacement from the TS: 1.7932 bohr amu^1/2\n",
+      "Displaced geometry has clashing atoms: False\n",
+      "\n",
+      "Atoms that move the most:\n",
+      "  atom  4 (C ) moved 0.152 Angstrom\n",
+      "  atom  6 (C ) moved 0.127 Angstrom\n",
+      "  atom  1 (C ) moved 0.126 Angstrom\n",
+      "  atom  3 (O ) moved 0.112 Angstrom\n",
+      "  atom  7 (H ) moved 0.089 Angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from pyqrc import QRCGenerator\n",
+    "\n",
+    "qrc = QRCGenerator(\n",
+    "    file=str(SCRATCH / \"claisen_ts.out\"),\n",
+    "    amplitude=0.3,\n",
+    "    nproc=4,\n",
+    "    mem=\"8GB\",\n",
+    "    route=None,     # None clones the route/keywords from the original job\n",
+    "    verbose=False,  # skip the .qrc summary file\n",
+    "    suffix=\"API\",\n",
+    "    val=None,       # or displace along the mode nearest this frequency (cm-1)\n",
+    "    num=None,       # or along this 1-indexed mode number\n",
+    "    write=False,    # compute only; no files are written\n",
+    ")\n",
+    "\n",
+    "freqs = np.asarray(qrc.FREQS)\n",
+    "print(\"Imaginary frequencies (cm-1):\", freqs[freqs < 0.0])\n",
+    "print(f\"Mass-weighted displacement from the TS: {qrc.MW_DISTANCE:.4f} bohr amu^1/2\")\n",
+    "print(\"Displaced geometry has clashing atoms:\", qrc.OVERLAPPED)\n",
+    "print()\n",
+    "\n",
+    "per_atom = np.linalg.norm(qrc.NEW_CARTESIAN - qrc.CARTESIAN, axis=1)\n",
+    "print(\"Atoms that move the most:\")\n",
+    "for i in np.argsort(per_atom)[::-1][:5]:\n",
+    "    print(f\"  atom {i + 1:>2} ({qrc.ATOMTYPES[i]:<2}) moved {per_atom[i]:.3f} Angstrom\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "487f9c17",
+   "metadata": {},
+   "source": [
+    "## Where the files went\n",
+    "\n",
+    "Everything generated above is in the `scratch/` subdirectory (ignored by git) — delete it when you are done. In real use you would submit the new input file (`*.inp`) to your scheduler and optimize.\n",
+    "\n",
+    "See the [project README](../../README.md) for the full option list and for the IRC-comparison benchmark behind the recommended amplitude of 0.3.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/qchem/generate_qrc_inputs.ipynb
+++ b/examples/qchem/generate_qrc_inputs.ipynb
@@ -1,0 +1,424 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b4b72ab6",
+   "metadata": {},
+   "source": [
+    "# Generating QRC inputs from Q-Chem frequency calculations\n",
+    "\n",
+    "pyQRC reads a completed frequency calculation and writes a new input file whose geometry has been displaced along one or more normal modes — Silva and Goodman's *Quick Reaction Coordinate* (QRC) approach. This notebook walks through the Q-Chem example files that ship in this directory.\n",
+    "\n",
+    "Requirements: `pip install pyqrc` (pulls in cclib and numpy).\n",
+    "\n",
+    "> **Note:** use a cclib *release* (e.g. 1.8.1, which `pip install pyqrc` provides). cclib development builds currently have a Q-Chem parsing regression — see the README compatibility notes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a19efd",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "pyQRC writes its new input files next to the file it reads, so we copy the example outputs into a `scratch/` subdirectory and run everything there. The helper below invokes the same `pyqrc` command line you would use in a terminal or HPC batch script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b744fa8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:31.094462Z",
+     "iopub.status.busy": "2026-06-11T15:35:31.094336Z",
+     "iopub.status.idle": "2026-06-11T15:35:31.100669Z",
+     "shell.execute_reply": "2026-06-11T15:35:31.100202Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "HERE = Path.cwd()                # this examples directory\n",
+    "SCRATCH = HERE / \"scratch\"\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir()\n",
+    "\n",
+    "for name in ['acetaldehyde.out', 'claisen_ts.out']:\n",
+    "    shutil.copy(HERE / name, SCRATCH / name)\n",
+    "\n",
+    "\n",
+    "def run_pyqrc(*args):\n",
+    "    \"\"\"Run the pyqrc command line inside the scratch directory.\"\"\"\n",
+    "    result = subprocess.run(\n",
+    "        [sys.executable, \"-m\", \"pyqrc\", *args],\n",
+    "        cwd=SCRATCH, capture_output=True, text=True,\n",
+    "    )\n",
+    "    print(result.stdout, end=\"\")\n",
+    "    if result.returncode != 0:\n",
+    "        print(result.stderr, end=\"\")\n",
+    "        raise RuntimeError(f\"pyqrc exited with code {result.returncode}\")\n",
+    "\n",
+    "\n",
+    "def show(filename, n=40):\n",
+    "    \"\"\"Print up to n lines of a file in the scratch directory.\"\"\"\n",
+    "    lines = (SCRATCH / filename).read_text().splitlines()\n",
+    "    print(\"\\n\".join(lines[:n]))\n",
+    "    if len(lines) > n:\n",
+    "        print(f\"... ({len(lines) - n} more lines)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b358c96",
+   "metadata": {},
+   "source": [
+    "## Example 1: remove an unwanted imaginary frequency\n",
+    "\n",
+    "This acetaldehyde optimization inadvertently produced a saddle point — it has one small imaginary frequency. By default pyQRC displaces along **all** imaginary modes, which is exactly what we want here: the displaced geometry breaks the symmetry of the saddle point, and re-optimizing it gives the true minimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e89875a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:31.102212Z",
+     "iopub.status.busy": "2026-06-11T15:35:31.102119Z",
+     "iopub.status.idle": "2026-06-11T15:35:31.777158Z",
+     "shell.execute_reply": "2026-06-11T15:35:31.776455Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   acetaldehyde.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"acetaldehyde.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e76783",
+   "metadata": {},
+   "source": [
+    "That wrote two files: `acetaldehyde_QRC.inp` (the new, displaced input — ready to submit) and `acetaldehyde_QRC.qrc` (a human-readable summary of the frequencies and the displacement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "33a13396",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:31.778837Z",
+     "iopub.status.busy": "2026-06-11T15:35:31.778695Z",
+     "iopub.status.idle": "2026-06-11T15:35:31.781164Z",
+     "shell.execute_reply": "2026-06-11T15:35:31.780678Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "$molecule\n",
+      "0 1\n",
+      " C  -0.23989603  -0.41400014  -0.01839886\n",
+      " O  -1.21878387   0.28856908   0.01499978\n",
+      " H  -0.34220289  -1.51972004  -0.08160123\n",
+      " C   1.16775303   0.13590817   0.00500103\n",
+      " H   1.91671284  -0.65642526   0.10346628\n",
+      " H   1.34472973   0.68481398  -0.93074441\n",
+      " H   1.26388921   0.85133056   0.83146815\n",
+      "$end\n",
+      "\n",
+      "$rem\n",
+      "   JOBTYPE opt\n",
+      "   METHOD M062X\n",
+      "   BASIS 6-31G(d,p)\n",
+      "$end\n",
+      "\n",
+      "@@@\n",
+      "\n",
+      "$molecule\n",
+      "   read\n",
+      "$end\n",
+      "\n",
+      "$rem\n",
+      "   JOBTYPE freq\n",
+      "   METHOD M062X\n",
+      "   BASIS 6-31G(d,p)\n",
+      "$end\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.inp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2bbafeac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:31.782385Z",
+     "iopub.status.busy": "2026-06-11T15:35:31.782284Z",
+     "iopub.status.idle": "2026-06-11T15:35:31.784371Z",
+     "shell.execute_reply": "2026-06-11T15:35:31.783927Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " pyQRC - a quick alternative to IRC calculations\n",
+      " version: 2.3.0 / author: Robert Paton / email: robert.paton@colostate.edu\n",
+      " Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;\n",
+      " Tet. Lett. 2005, 46, 2067-2069.\n",
+      "\n",
+      "                -----ORIGINAL GEOMETRY------\n",
+      "                       X         Y         Z\n",
+      "   C           -0.239896 -0.414000  0.000001\n",
+      "   O           -1.218784  0.288569 -0.000000\n",
+      "   H           -0.342203 -1.519720 -0.000001\n",
+      "   C            1.167753  0.135908  0.000001\n",
+      "   H            1.916713 -0.656425  0.000066\n",
+      "   H            1.304330  0.768014 -0.881144\n",
+      "   H            1.304289  0.768131  0.881068\n",
+      "\n",
+      "                ----HARMONIC FREQUENCIES----\n",
+      "                    Freq  Red mass   F const\n",
+      "               -169.8000    1.1906    0.0202\n",
+      "                507.7000    2.6427    0.4013\n",
+      "                754.9600    1.1713    0.3934\n",
+      "                948.6000    2.1552    1.1426\n",
+      "               1107.9600    2.0111    1.4545\n",
+      "               1140.6500    1.7254    1.3226\n",
+      "               1383.0700    1.2218    1.3770\n",
+      "... (23 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"acetaldehyde_QRC.qrc\", n=24)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74f0ee23",
+   "metadata": {},
+   "source": [
+    "## Example 2: map a reaction coordinate (the namesake QRC)\n",
+    "\n",
+    "For a transition state — here a Claisen rearrangement — the quick alternative to an IRC is two displaced inputs: one along the imaginary mode (`--amp 0.3`) and one in the reverse direction (`--amp -0.3`). Optimizing both gives the reactant and product the TS connects. The benchmark in the README found an amplitude of **0.3** performs best, hence the values used here; `--name` controls the suffix of the generated files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7a247ebe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:31.785580Z",
+     "iopub.status.busy": "2026-06-11T15:35:31.785482Z",
+     "iopub.status.idle": "2026-06-11T15:35:32.664619Z",
+     "shell.execute_reply": "2026-06-11T15:35:32.664086Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "o   claisen_ts.out had 1 imaginary frequencies: processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"0.3\", \"--name\", \"QRCF\")\n",
+    "run_pyqrc(\"claisen_ts.out\", \"--nproc\", \"4\", \"--mem\", \"8GB\", \"--amp\", \"-0.3\", \"--name\", \"QRCR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b010b646",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:32.666565Z",
+     "iopub.status.busy": "2026-06-11T15:35:32.666430Z",
+     "iopub.status.idle": "2026-06-11T15:35:32.670008Z",
+     "shell.execute_reply": "2026-06-11T15:35:32.669465Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "$molecule\n",
+      "0 1\n",
+      " C   1.57725331  -0.64016682  -0.31479468\n",
+      " C   1.24570603   0.51979610   0.25798469\n",
+      " O   0.29520089   1.34820085  -0.23764386\n",
+      " C  -1.17384866   0.87557915   0.16086163\n",
+      " C  -1.32123400  -0.51574983  -0.29716709\n",
+      " C  -0.65796743  -1.47825339   0.34671231\n",
+      " H   2.27854629  -1.31766805   0.16438926\n",
+      " H   1.22653751  -0.90042035  -1.31761742\n",
+      " H   1.60308445   0.76370424   1.26300924\n",
+      " H  -1.78054359   1.61880696  -0.35396660\n",
+      " H  -1.24016236   0.99745295   1.25640546\n",
+      " H  -1.63809993  -0.67009255  -1.32561129\n",
+      "... (22 more lines)\n",
+      "============================================================\n",
+      "$molecule\n",
+      "0 1\n",
+      " C   1.37145331  -0.76136682  -0.26859468\n",
+      " C   1.23910603   0.57139610   0.25198469\n",
+      " O   0.51240089   1.40820085  -0.27064386\n",
+      " C  -1.45824866   0.76817915   0.20586163\n",
+      " C  -1.33803400  -0.47494983  -0.29776709\n",
+      " C  -0.42216743  -1.41225339   0.30471231\n",
+      " H   2.11234629  -1.41246805   0.19498926\n",
+      " H   1.28293751  -0.86142035  -1.35901742\n",
+      " H   1.61868445   0.73490424   1.28160924\n",
+      " H  -1.92994359   1.57740696  -0.34316660\n",
+      " H  -1.19456236   0.99385295   1.24680546\n",
+      " H  -1.62909993  -0.65509255  -1.33041129\n",
+      "... (22 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "show(\"claisen_ts_QRCF.inp\", n=14)\n",
+    "print(\"=\" * 60)\n",
+    "show(\"claisen_ts_QRCR.inp\", n=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34dd3724",
+   "metadata": {},
+   "source": [
+    "## Using the Python API instead of the CLI\n",
+    "\n",
+    "The same machinery is importable. `QRCGenerator` parses the output, computes the displaced geometry, and (unless `write=False`) writes the files in one go. With `write=False` you can inspect the displacement before committing anything to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "de8f151f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T15:35:32.671352Z",
+     "iopub.status.busy": "2026-06-11T15:35:32.671257Z",
+     "iopub.status.idle": "2026-06-11T15:35:33.000579Z",
+     "shell.execute_reply": "2026-06-11T15:35:32.999944Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imaginary frequencies (cm-1): [-588.44]\n",
+      "Mass-weighted displacement from the TS: 1.7830 bohr amu^1/2\n",
+      "Displaced geometry has clashing atoms: False\n",
+      "\n",
+      "Atoms that move the most:\n",
+      "  atom  4 (C ) moved 0.154 Angstrom\n",
+      "  atom  6 (C ) moved 0.124 Angstrom\n",
+      "  atom  1 (C ) moved 0.122 Angstrom\n",
+      "  atom  3 (O ) moved 0.114 Angstrom\n",
+      "  atom  7 (H ) moved 0.097 Angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from pyqrc import QRCGenerator\n",
+    "\n",
+    "qrc = QRCGenerator(\n",
+    "    file=str(SCRATCH / \"claisen_ts.out\"),\n",
+    "    amplitude=0.3,\n",
+    "    nproc=4,\n",
+    "    mem=\"8GB\",\n",
+    "    route=None,     # None clones the route/keywords from the original job\n",
+    "    verbose=False,  # skip the .qrc summary file\n",
+    "    suffix=\"API\",\n",
+    "    val=None,       # or displace along the mode nearest this frequency (cm-1)\n",
+    "    num=None,       # or along this 1-indexed mode number\n",
+    "    write=False,    # compute only; no files are written\n",
+    ")\n",
+    "\n",
+    "freqs = np.asarray(qrc.FREQS)\n",
+    "print(\"Imaginary frequencies (cm-1):\", freqs[freqs < 0.0])\n",
+    "print(f\"Mass-weighted displacement from the TS: {qrc.MW_DISTANCE:.4f} bohr amu^1/2\")\n",
+    "print(\"Displaced geometry has clashing atoms:\", qrc.OVERLAPPED)\n",
+    "print()\n",
+    "\n",
+    "per_atom = np.linalg.norm(qrc.NEW_CARTESIAN - qrc.CARTESIAN, axis=1)\n",
+    "print(\"Atoms that move the most:\")\n",
+    "for i in np.argsort(per_atom)[::-1][:5]:\n",
+    "    print(f\"  atom {i + 1:>2} ({qrc.ATOMTYPES[i]:<2}) moved {per_atom[i]:.3f} Angstrom\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7588d6e3",
+   "metadata": {},
+   "source": [
+    "## Where the files went\n",
+    "\n",
+    "Everything generated above is in the `scratch/` subdirectory (ignored by git) — delete it when you are done. In real use you would submit the new input file (`*.inp`) to your scheduler and optimize.\n",
+    "\n",
+    "See the [project README](../../README.md) for the full option list and for the IRC-comparison benchmark behind the recommended amplitude of 0.3.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -782,14 +782,21 @@ def main() -> int:
     )
     parser.add_argument(
         "--qcoord", dest="qcoord", action="store_true", default=False,
-        help="request automatic single point calculation along a particular normal mode"
+        help="(deprecated, removal in 3.0) run single points along normal modes with g16"
     )
     parser.add_argument(
         "--nummodes", dest="nummodes", type=str, default='all',
-        metavar="NUMMODES", help="number of modes for automatic single point calculation"
+        metavar="NUMMODES", help="(deprecated, removal in 3.0) number of modes for --qcoord"
     )
 
     args = parser.parse_args()
+
+    if args.qcoord:
+        print(
+            'Warning - --qcoord is deprecated and will be removed in pyQRC 3.0: '
+            'generate displaced inputs with the default mode and submit them '
+            'through your scheduler instead'
+        )
 
     # Collect input files, expanding any glob patterns the shell left unexpanded
     files = []

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -10,7 +10,7 @@ Based on: Goodman, J. M.; Silva, M. A. Tet. Lett. 2003, 44, 8233-8236;
           Tet. Lett. 2005, 46, 2067-2069.
 """
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 __author__ = 'Robert Paton'
 __email__ = 'robert.paton@colostate.edu'
 

--- a/pyqrc/pyQRC.py
+++ b/pyqrc/pyQRC.py
@@ -487,9 +487,38 @@ class QRCGenerator:
         return self.NEW_CARTESIAN
 
     def write_files(self) -> None:
-        """Write the verbose .qrc summary (if verbose) and the new input file."""
+        """Write the verbose .qrc summary (if verbose) and the new input file.
+
+        Raises:
+            QRCParseError: If a Q-Chem input is requested but the method or
+                basis set could not be parsed from the output. Raised before
+                any file is written.
+        """
         file_path = Path(self.file)
         nat = self.NATOMS
+
+        # Resolve output format and route, preferring cclib metadata
+        format_type = self._format_type
+        route = self.route
+        if format_type is None or route is None:
+            gdata = OutputData(self.file)
+            if format_type is None:
+                format_type = gdata.format
+            if route is None:
+                route = gdata.JOBTYPE
+            if gdata.format == "Gaussian" and gdata.TERMINATION != "normal":
+                print(
+                    f'Warning - {self.file} did not terminate normally: '
+                    'the parsed geometry and normal modes may be incomplete'
+                )
+
+        if format_type == "QChem" and (self._func is None or self._basis is None):
+            raise QRCParseError(
+                f"Cannot write a Q-Chem input for '{self.file}': the method "
+                "and/or basis set could not be parsed from the output, so the "
+                "input would contain 'METHOD None'. Check that the output file "
+                "is complete."
+            )
 
         if self.verbose:
             with Logger(file_path.stem, "qrc", self.suffix) as log:
@@ -510,16 +539,6 @@ class QRCGenerator:
                             f'{self.DISPS[mode][atom][2]:9.6f}'
                         )
                 log.write(f'\n   STRUCTURE MOVED BY {self.MW_DISTANCE:.3f} Bohr amu^1/2 \n')
-
-        # Resolve output format and route, preferring cclib metadata
-        format_type = self._format_type
-        route = self.route
-        if format_type is None or route is None:
-            gdata = OutputData(self.file)
-            if format_type is None:
-                format_type = gdata.format
-            if route is None:
-                route = gdata.JOBTYPE
 
         self._write_input_file(
             file_path, format_type, self.suffix, self.nproc, self.mem, route,

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -1712,6 +1712,115 @@ class TestComputeOnly:
         assert not np.array_equal(qrc.NEW_CARTESIAN, qrc.CARTESIAN)
 
 
+class TestQChemMissingMetadata:
+    """Q-Chem inputs must never be written with METHOD None/BASIS None."""
+
+    @QCHEM_DEV_CCLIB_SKIP
+    def test_missing_method_raises_before_writing(
+        self, qchem_acetaldehyde, temp_workdir
+    ):
+        """Missing functional metadata raises QRCParseError, writes nothing."""
+        shutil.copy(qchem_acetaldehyde, temp_workdir)
+        local_file = temp_workdir / qchem_acetaldehyde.name
+
+        qrc = QRCGenerator(
+            file=str(local_file),
+            amplitude=0.2,
+            nproc=1,
+            mem="4GB",
+            route=None,
+            verbose=True,
+            suffix="QRC",
+            val=None,
+            num=None,
+            write=False,
+        )
+        qrc._func = None
+
+        with pytest.raises(QRCParseError, match="METHOD None"):
+            qrc.write_files()
+
+        assert not (temp_workdir / f"{local_file.stem}_QRC.inp").exists()
+        assert not (temp_workdir / f"{local_file.stem}_QRC.qrc").exists()
+
+    @QCHEM_DEV_CCLIB_SKIP
+    def test_missing_basis_raises_before_writing(
+        self, qchem_acetaldehyde, temp_workdir
+    ):
+        """Missing basis-set metadata raises QRCParseError, writes nothing."""
+        shutil.copy(qchem_acetaldehyde, temp_workdir)
+        local_file = temp_workdir / qchem_acetaldehyde.name
+
+        qrc = QRCGenerator(
+            file=str(local_file),
+            amplitude=0.2,
+            nproc=1,
+            mem="4GB",
+            route=None,
+            verbose=True,
+            suffix="QRC",
+            val=None,
+            num=None,
+            write=False,
+        )
+        qrc._basis = None
+
+        with pytest.raises(QRCParseError, match="basis"):
+            qrc.write_files()
+
+        assert not (temp_workdir / f"{local_file.stem}_QRC.inp").exists()
+
+
+class TestAbnormalTermination:
+    """Gaussian outputs without normal termination produce a warning."""
+
+    def test_abnormal_termination_warns_but_writes(
+        self, g16_acetaldehyde, temp_workdir, capsys
+    ):
+        """Stripped 'Normal termination' line warns; input is still written."""
+        local_file = temp_workdir / g16_acetaldehyde.name
+        lines = g16_acetaldehyde.read_text().splitlines(keepends=True)
+        local_file.write_text(
+            ''.join(line for line in lines if 'Normal termination' not in line)
+        )
+
+        QRCGenerator(
+            file=str(local_file),
+            amplitude=0.2,
+            nproc=1,
+            mem="4GB",
+            route=None,
+            verbose=True,
+            suffix="QRC",
+            val=None,
+            num=None,
+        )
+
+        assert 'did not terminate normally' in capsys.readouterr().out
+        assert (temp_workdir / f"{local_file.stem}_QRC.com").exists()
+
+    def test_normal_termination_no_warning(
+        self, g16_acetaldehyde, temp_workdir, capsys
+    ):
+        """A normally terminated output produces no termination warning."""
+        shutil.copy(g16_acetaldehyde, temp_workdir)
+        local_file = temp_workdir / g16_acetaldehyde.name
+
+        QRCGenerator(
+            file=str(local_file),
+            amplitude=0.2,
+            nproc=1,
+            mem="4GB",
+            route=None,
+            verbose=True,
+            suffix="QRC",
+            val=None,
+            num=None,
+        )
+
+        assert 'did not terminate normally' not in capsys.readouterr().out
+
+
 class TestMainModule:
     """Tests for __main__.py entry point."""
 

--- a/tests/test_pyqrc.py
+++ b/tests/test_pyqrc.py
@@ -1541,6 +1541,21 @@ class TestQcoordMode:
 
         assert exit_code == 0
 
+        # Deprecated mode warns once
+        assert '--qcoord is deprecated' in capsys.readouterr().out
+
+    def test_default_mode_no_deprecation_warning(
+        self, g16_claisen_ts, tmp_path, monkeypatch, capsys
+    ):
+        """The default (non --qcoord) mode prints no deprecation warning."""
+        monkeypatch.chdir(tmp_path)
+        shutil.copy(g16_claisen_ts, tmp_path)
+        local_file = tmp_path / g16_claisen_ts.name
+
+        monkeypatch.setattr('sys.argv', ['pyqrc', str(local_file)])
+        assert main() == 0
+        assert 'deprecated' not in capsys.readouterr().out
+
     def test_qcoord_limited_modes(self, g16_claisen_ts, tmp_path, monkeypatch):
         """Test --qcoord with limited nummodes creates only specified directories."""
 


### PR DESCRIPTION
Finishes the June 2026 audit roadmap — with D1 now resolved, this closes every remaining roadmap item.

**Stacked on #17** — includes its commits until that merges; the diff will shrink afterwards.

## ROADMAP 3.2 — no more `METHOD None` Q-Chem inputs
- `write_files()` now raises `QRCParseError` (before any file is written) when a Q-Chem input is requested but cclib could not parse the functional or basis set. Previously the $rem block was silently written with literal `METHOD None` / `BASIS None` — a broken input that costs cluster time.
- The previously unused `TERMINATION` attribute (public API, so kept rather than deleted) now backs a warning when a Gaussian output lacks a "Normal termination" line; the input file is still written.
- Four new behavior tests: missing method/basis each raise with nothing written; abnormal termination warns but writes; normal termination stays silent.

## ROADMAP 3.4 — README options table audited against `pyqrc --help`
- Option column uses the exact metavars from `--help`; rows reordered to match. Descriptions and defaults were verified accurate (including the v2.2.0 `--freq` nearest-match semantics).

## D1 resolved — `--qcoord`/`--nummodes` deprecated, removal in 3.0
- Maintainer confirmed no known usage. The mode was unrunnable from pip installs for years with zero bug reports, and it runs Gaussian sequentially on the invoking machine — the wrong model for HPC users, who submit through a scheduler.
- Using `--qcoord` now prints a deprecation warning pointing at the default generate-and-submit workflow; `--help` and the README say the same. ROADMAP 3.1 (robustness work) is closed as superseded; removing the mode (and `run_g16.sh`/`g16_opt`/`run_irc`) becomes the 3.0 task.

## Release
- **Version bumped to 2.3.0**: previously "successful" Q-Chem runs that wrote `METHOD None` inputs now exit 1 (a CLI behavior change), plus the deprecation. This PR description doubles as the release note.

Verified locally: 122 passed in ~5 s, pylint 9.95/10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runnable example Jupyter notebooks demonstrating QRC generation for Gaussian 16, ORCA 5/6, and Q-Chem workflows.

* **Deprecations**
  * `--qcoord` and `--nummodes` CLI options are now deprecated; removal planned for v3.0.

* **Bug Fixes**
  * Improved error handling for Q-Chem inputs with missing method/basis metadata.
  * Added warning when Gaussian output terminates abnormally.

* **Documentation**
  * Updated CLI options table with clearer descriptions and examples.
  * Enhanced README with deprecation notices and example file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->